### PR TITLE
added GAP_PKGS_TO_BUILD entry in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
     - GAPROOT=gaproot
     - COVDIR=coverage
-    - GAP_PKGS_TO_BUILD="semigroups"
+    - GAP_PKGS_TO_BUILD="io profiling semigroups"
 
 addons:
   apt_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   global:
     - GAPROOT=gaproot
     - COVDIR=coverage
+    - GAP_PKGS_TO_BUILD="semigroups"
 
 addons:
   apt_packages:


### PR DESCRIPTION
Still trying to sort out the diffs with Travis checks. 
Problem is that XModAlg requires XMod which requires groupoids which only suggests Semigroups. 
So the Travis check does not attempt to load Semigroups, hence the diff in algebra generators. 
Alexander K. suggests adding:     - GAP_PKGS_TO_BUILD="semigroups"
to the .travis.yml file.  If this works (and Semigroups 3.0.14 is available) then the temporary changes to the tests and to files alg2obj.gi, alg2map.gi can be removed.