### PR TITLE
Revert "added GAP_PKGS_TO_BUILD entry in .travis.yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ env:
   global:
     - GAPROOT=gaproot
     - COVDIR=coverage
-    - GAP_PKGS_TO_BUILD="io profiling semigroups"
 
 addons:
   apt_packages:


### PR DESCRIPTION
Reverts gap-packages/xmodalg#17
This was only an experimental addition, which did not work correctly. 
The reason for making it a PR is that tests are then performed. 
I should have marked the PR with "DO NOT MERGE", but not sure how to do this. 
Semigroups 3.0.15 is now available, so I will check to see whether it makes any difference. 
So DO NOT MERGE for now. 