### PR TITLE
now AlgebraHomomorphismByFunction2 avoiding conflict with FR

### DIFF
--- a/doc/xmod.xml
+++ b/doc/xmod.xml
@@ -267,7 +267,7 @@ gap> SetName( S, "<e5>" );
 gap> RS := Cartesian( R, S );; 
 gap> SetName( RS, "GF(2^2)[k4] x <e5>" ); 
 gap> act := AlgebraAction( R, RS, S );;
-gap> bdy := AlgebraHomomorphismByFunction( S, R, r->r );
+gap> bdy := AlgebraHomomorphismByFunction2( S, R, r->r );
 MappingByFunction( <e5>, GF(2^2)[k4], function( r ) ... end )
 gap> IsAlgebraAction( act ); 
 true

--- a/lib/alg2obj.gd
+++ b/lib/alg2obj.gd
@@ -16,7 +16,7 @@ DeclareGlobalFunction( "MultipleAlgebra",
 
 DeclareProperty( "IsMultipleAlgebra", IsList );
 
-DeclareOperation( "AlgebraHomomorphismByFunction",
+DeclareOperation( "AlgebraHomomorphismByFunction2",
     [ IsObject, IsObject, IsFunction ] );
     
 DeclareOperation( "MultipleHomomorphism",

--- a/lib/alg2obj.gi
+++ b/lib/alg2obj.gi
@@ -209,10 +209,10 @@ end );
 
 #############################################################################
 ##
-#F  AlgebraHomomorphismByFunction( <D>, <E>, <fun> )
+#F  AlgebraHomomorphismByFunction2( <D>, <E>, <fun> )
 ##
-InstallMethod( AlgebraHomomorphismByFunction, "for,for,for", true, 
-    [ IsObject, IsObject, IsFunction ], 0,
+InstallMethod( AlgebraHomomorphismByFunction2, "for,for,for", true, 
+    [ IsAlgebra, IsAlgebra, IsFunction ], 0,
 function ( A,B,C )
     local act,arg,narg,usage,error,fun;        # mapping <map>, result
     error := "\n Error: Bir Cebir Girilmeli; \n";
@@ -242,8 +242,8 @@ function ( A )
 
     local mu, B; # mapping <map>, result
     B := MultipleAlgebra(A);
-    mu := AlgebraHomomorphismByFunction( A, B, 
-              r -> AlgebraHomomorphismByFunction(A,A,x->r*x) );
+    mu := AlgebraHomomorphismByFunction2( A, B, 
+              r -> AlgebraHomomorphismByFunction2(A,A,x->r*x) );
     SetSource(mu,A);
     SetRange(mu,B);
     # return the mapping
@@ -259,7 +259,7 @@ function ( M,R )
 
     local   mu,B;        # mapping <map>, result
      
-    mu := AlgebraHomomorphismByFunction(M,R,r->Zero(R));  
+    mu := AlgebraHomomorphismByFunction2(M,R,r->Zero(R));  
     SetSource(mu,M);
     SetRange(mu,R);
     # return the mapping
@@ -843,7 +843,7 @@ function( A,I )
     # AI := Cartesian(A,I);
     # act := AlgebraAction(A,AI,I);
     act := AlgebraAction5(A,I);
-    bdy := AlgebraHomomorphismByFunction(I,A,i->i);
+    bdy := AlgebraHomomorphismByFunction2(I,A,i->i);
     IsAlgebraAction(act);
     IsAlgebraHomomorphism(bdy);
     PM := PreXModAlgebraByBoundaryAndAction( bdy, act );

--- a/tst/cat1.tst
+++ b/tst/cat1.tst
@@ -22,7 +22,7 @@ gap> SetName( S, "<e5>" );
 gap> RS := Cartesian( R, S );; 
 gap> SetName( RS, "GF(2^2)[k4] x <e5>" ); 
 gap> act := AlgebraAction( R, RS, S );;
-gap> bdy := AlgebraHomomorphismByFunction( S, R, r->r );;
+gap> bdy := AlgebraHomomorphismByFunction2( S, R, r->r );;
 gap> IsAlgebraAction( act );; 
 gap> IsAlgebraHomomorphism( bdy );; 
 gap> XM := PreXModAlgebraByBoundaryAndAction( bdy, act );;

--- a/tst/xmod.tst
+++ b/tst/xmod.tst
@@ -88,7 +88,7 @@ gap> SetName( S, "<e5>" );
 gap> RS := Cartesian( R, S );; 
 gap> SetName( RS, "GF(2^2)[k4] x <e5>" ); 
 gap> act := AlgebraAction( R, RS, S );;
-gap> bdy := AlgebraHomomorphismByFunction( S, R, r->r );
+gap> bdy := AlgebraHomomorphismByFunction2( S, R, r->r );
 MappingByFunction( <e5>, GF(2^2)[k4], function( r ) ... end )
 gap> IsAlgebraAction( act ); 
 true


### PR DESCRIPTION
Alex K. has reported XModAlg segfaulting with AllPackagesLoaded. 
Possibly this is due to AlgebraHomomorphismByFunction being defined in different ways in FR and XModAlg.  This temporary fix renames the XModAlg version AlgebraHomomorphismByFunction2. 