### PR TITLE
Updating conversion functions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,13 @@
 /doc/*.six
 /doc/*.tex
 /doc/*.toc
+/doc/title.xml
+/doc/XModAlg.xml
 /doc/manual.pdf
 /doc/bib.xml.bib
+
+/tst/cat1.g
+/tst/xmod.g
+/tst/convert.g
 
 /gh-pages/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 # CHANGES to the 'XModAlg' package
 
-## 1.17 -> 1.18
+## 1.17 -> 1.18 (00/10/18)
+ * (09/10/18) Conversion files: use "Of", not "By".  Delete SDproduct. 
  * (23/09/18) PreCat1Obj replaced by PreCat1AlgebraByTailHeadEmbedding 
  * (22/09/18) split off convert.xml and convert.tst from cat1.xml and cat1.tst 
 
-## 1.16 -> 1.17 
+## 1.16 -> 1.17 (30/08/18)
  * (29/08/18) added method for ImagesSource at end of alg2map.gi 
  * (28/08/18) update examples to avoid travis failures 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGES to the 'XModAlg' package
 
+## 1.17 -> 1.18
+ * (23/09/18) PreCat1Obj replaced by PreCat1AlgebraByTailHeadEmbedding 
+ * (22/09/18) split off convert.xml and convert.tst from cat1.xml and cat1.tst 
+
 ## 1.16 -> 1.17 
  * (29/08/18) added method for ImagesSource at end of alg2map.gi 
  * (28/08/18) update examples to avoid travis failures 

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -9,7 +9,7 @@ SetPackageInfo( rec(
 PackageName := "XModAlg",
 Subtitle := "Crossed Modules and Cat1-Algebras",
 Version := "1.17dev",
-Date := "00/09/2018",
+Date := "00/10/2018",
 
 Persons := [
     rec(

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -9,7 +9,7 @@ SetPackageInfo( rec(
 PackageName := "XModAlg",
 Subtitle := "Crossed Modules and Cat1-Algebras",
 Version := "1.17",
-Date := "28/08/2018",
+Date := "30/08/2018",
 
 Persons := [
     rec(

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -8,8 +8,8 @@ SetPackageInfo( rec(
 
 PackageName := "XModAlg",
 Subtitle := "Crossed Modules and Cat1-Algebras",
-Version := "1.17",
-Date := "30/08/2018",
+Version := "1.17dev",
+Date := "00/09/2018",
 
 Persons := [
     rec(

--- a/doc/cat1.xml
+++ b/doc/cat1.xml
@@ -175,34 +175,38 @@ Cat1-algebra [..=>..] :-
 
 <ManSection>
    <Oper Name="Cat1AlgebraSelect"
-         Arg="gf gpsize gpnum num" />
+         Arg="n gpsize gpnum num" />
 <Description> 
 The <Ref Oper="Cat1Algebra"/> function may also be used to select a 
-cat<M>^{1}</M>-algebra from a data file. All cat<M>^{1}</M>-structures on
-commutative algebras are stored in a list in file cat1algdata.g. The data is read into the list CAT1ALG_LIST only when this function is called.
+cat<M>^{1}</M>-algebra from a data file. 
+All cat<M>^{1}</M>-structures on commutative algebras are stored in a list 
+in file <File>cat1algdata.g</File>. 
+The data is read into the list <C>CAT1ALG_LIST</C> 
+only when this function is called.
 <P/>
 The function <C>Cat1AlgebraSelect</C> may be used in four ways:
 <List>
 <Item> 
-<C>Cat1AlgebraSelect( gf )</C> returns the list of possible size of 
-Galois field or the list of possible size of groups with given Galois field. 
+<C>Cat1AlgebraSelect( n )</C> returns the list of possible sizes of groups 
+for group algebras with Galois field <M>GF(n)</M>. 
 </Item>
 <Item> 
-<C>Cat1AlgebraSelect( gf, gpsize )</C> returns the list of possible sizes of a group with given Galois field, or the list of possible 
-number of groups with given Galois field and size of group.
+<C>Cat1AlgebraSelect( n, m )</C> returns the list of allowable 
+group numbers with given Galois field <M>GF(n)</M> 
+and groups of size <M>m</M>.
 </Item>
 <Item> 
-<C>Cat1AlgebraSelect( gf, gpsize, gpnum )</C> returns the list of possible 
-number of group with given Galois field and size of group or the list of 
-possible cat<M>^{1}</M>-structures with given Galois field and group.
+<C>Cat1AlgebraSelect( n, m, k )</C> returns the list of possible 
+cat<M>^{1}</M>-algebra structures with given Galois field <M>GF(n)</M> 
+and group number <M>k</M> of size <M>m</M>.
 </Item>
 <Item> 
-<C>Cat1AlgebraSelect( gf, gpsize, gpnum, num )</C> 
-(or just <C>Cat1Algebra( gf, gpsize, gpnum, num )</C>) 
-returns the chosen cat<M>^{1}</M>-algebra.
+<C>Cat1AlgebraSelect( n, m, k, j )</C> 
+(or simply <C>Cat1Algebra( n, m, k, j )</C>) returns the 
+<M>j</M>-th cat<M>^{1}</M>-algebra structure with these other parameters.
 </Item>
 </List>
-Now, we will give an example for the usage of this function.
+Now, we give examples of the use of this function.
 <P/>
 </Description> 
 </ManSection> 
@@ -211,11 +215,11 @@ Now, we will give an example for the usage of this function.
 <![CDATA[
 gap> C := Cat1AlgebraSelect( 11 );
 |--------------------------------------------------------|
-| 11 is invalid number for Galois Field (gf)             |
-| Possible numbers for the gf in the Data :              |
+| 11 is invalid number for Galois Field (GFnum)             |
+| Possible numbers for GFnum in the Data :              |
 |--------------------------------------------------------|
  [ 2, 3, 4, 5, 7 ]
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 fail
 gap> C := Cat1AlgebraSelect( 4, 12 );
 |--------------------------------------------------------|
@@ -223,7 +227,7 @@ gap> C := Cat1AlgebraSelect( 4, 12 );
 | Possible numbers for the gpsize for GF(4) in the Data: |
 |--------------------------------------------------------|
  [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 fail
 gap> C := Cat1AlgebraSelect( 2, 6, 3 );
 |--------------------------------------------------------|
@@ -231,7 +235,7 @@ gap> C := Cat1AlgebraSelect( 2, 6, 3 );
 | Possible numbers for the gpnum in the Data :           |
 |--------------------------------------------------------|
  [ 1, 2 ]
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 fail
 gap> C := Cat1AlgebraSelect( 2, 6, 2 );
 There are 4 cat1-structures for the algebra GF(2)_c6.
@@ -242,7 +246,7 @@ There are 4 cat1-structures for the algebra GF(2)_c6.
 | -----         [ 2, 14 ]               [ 2, 14 ]        |
 | -----         [ 2, 50 ]               [ 2, 50 ]        |
 |--------------------------------------------------------|
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 Algebra has generators [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3)(4,5) ]
 4
 gap> C0 := Cat1AlgebraSelect( 4, 6, 2, 2 );

--- a/doc/cat1.xml
+++ b/doc/cat1.xml
@@ -68,14 +68,12 @@ The homomorphisms <M>t,h</M> and <M>e</M> are called the <E>tail map</E>,
 <ManSection>
    <Func Name="Cat1Algebra"
          Arg="args" />
-   <Oper Name="PreCat1Obj"
-         Arg="t h e" />
    <Oper Name="PreCat1AlgebraByEndomorphisms"
          Arg="t h" />
-   <Oper Name="PreCat1AlgebraObj"
-         Arg="C" />
+   <Oper Name="PreCat1AlgebraByTailHeadEmbedding"
+         Arg="t h e" />
    <Oper Name="PreCat1Algebra"
-         Arg="C" />
+         Arg="args" />
    <Prop Name="IsIdentityCat1Algebra"
          Arg="C" />
    <Prop Name="IsCat1Algebra"
@@ -83,11 +81,13 @@ The homomorphisms <M>t,h</M> and <M>e</M> are called the <E>tail map</E>,
    <Prop Name="IsPreCat1Algebra"
          Arg="C" />
 <Description>
-The operations listed above are used for construction of precat<M>^{1}</M> 
+The operations listed above are used for construction of precat<M>^{1}</M>- 
 and cat<M>^{1}</M>-algebra structures. 
 The function <C>Cat1Algebra</C> selects the operation from the
 above implementations up to user's input. 
-The operation <C>PreCat1AlgebraObj</C> is used for preserving the implementations,
+The operations <C>PreCat1AlgebraByEndomorphisms</C> 
+and <C>PreCat1AlgebraByTailHeadEmbedding</C> 
+are used with particular choices of algebra homomorphisms. 
 
 </Description> 
 </ManSection> 
@@ -142,7 +142,7 @@ gap> Print( mgiRA, "\n" );
   [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3) ] ], 
   [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
   [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,3,2) ] ] ]
-gap> C4 := PreCat1Obj( homAR[6], homAR[6], homRA[8] );
+gap> C4 := PreCat1AlgebraByTailHeadEmbedding( homAR[6], homAR[6], homRA[8] );
 [AlgebraWithOne( GF(2), [ (Z(2)^0)*(1,2,3)(4,5) ] ) -> AlgebraWithOne( GF(2), 
 [ (Z(2)^0)*(1,2,3) ] )]
 gap> IsCat1Algebra( C4 );
@@ -511,80 +511,5 @@ false
 </Example>
 
 </Section> 
-
-
-<Section> 
-
-<Heading>Equivalent Categories</Heading> 
-
-The categories <M>\mathbf{Cat1Alg}</M> (cat<M>^{1}</M>-algebras) 
-and <M>\mathbf{XModAlg}</M> (crossed modules) 
-are naturally equivalent <Cite Key="ellis1"/>.  
-This equivalence is outlined in what follows. 
-For a given crossed module <M>(\partial : A \rightarrow R)</M> 
-we can construct the semidirect product <M>R\ltimes A</M>
-thanks to the action of <M>R</M> on <M>A</M>. 
-If we define <M>t,h : R\ltimes A \rightarrow R</M> 
-and <M>e : R \rightarrow R \ltimes A</M> by 
-<Display>
-t(r,a) = r, \qquad 
-h(r,a) = r+\partial(a), \qquad 
-e(r) = (r,0), 
-</Display>
-respectively, then 
-<M>\mathcal{C} = (e;t,h : R \ltimes A \rightarrow R)</M> 
-is a cat<M>^{1}-</M>algebra.
-<P/> 
-Conversely, for a given cat<M>^{1}</M>-algebra 
-<M>\mathcal{C}=(e;t,h : A \rightarrow R)</M>, 
-the map <M>\partial : \ker t \rightarrow R</M> is a crossed module, 
-where the action is multiplication action and 
-<M>\partial</M> is the restriction of <M>h</M> to <M>\ker t</M>. 
-
-
-<ManSection>
-   <Oper Name="PreCat1ByPreXMod"
-         Arg="X0" />
-   <Oper Name="PreXModAlgebraByPreCat1Algebra"
-         Arg="C" />
-   <Oper Name="Cat1AlgebraByXModAlgebra"
-         Arg="X0" />
-   <Oper Name="XModAlgebraByCat1Algebra"
-         Arg="C" />
-<Description> 
-These operations are used for constructing a cat<M>^{1}</M>-algebra 
-from a given crossed module, and conversely.
-</Description>
-</ManSection> 
-
-<Example>
-<![CDATA[
-gap> CXM := Cat1AlgebraByXModAlgebra( XM );
-[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
-gap> X3 := XModAlgebraByCat1Algebra( C3 ); 
-[Algebra( GF(2), [ <zero> of ..., <zero> of ..., <zero> of ... 
- ] )->Algebra( GF(2), 
-[ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ] )]
-gap> Display( X3 ); 
-
-Crossed module [..->..] :- 
-: Source algebra has generators:
-  [ <zero> of ..., <zero> of ..., <zero> of ... ]
-: Range algebra has generators:
-  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
-: Boundary homomorphism maps source generators to:
-  [ <zero> of ..., <zero> of ..., <zero> of ... ]
-]]>
-</Example>
-
-Since all these operations are linked to the functions 
-<Ref Oper="Cat1Algebra"/> and <Ref Oper="XModAlgebra"/>, 
-all of them can be done by using these two functions. 
-We may also use the function <Ref Oper="Cat1Algebra"/> 
-instead of the operation <Ref Oper="Cat1AlgebraSelect"/>.
-
-</Section>
 
 </Chapter>

--- a/doc/convert.xml
+++ b/doc/convert.xml
@@ -40,49 +40,75 @@ Conversely, for a given cat<M>^{1}</M>-algebra
 the map <M>\partial : \ker t \rightarrow R</M> is a crossed module, 
 where the action is multiplication action and 
 <M>\partial</M> is the restriction of <M>h</M> to <M>\ker t</M>. 
-
-<ManSection>
-   <Oper Name="PreCat1ByPreXMod"
-         Arg="X0" />
-   <Oper Name="PreXModAlgebraByPreCat1Algebra"
-         Arg="C" />
-   <Oper Name="Cat1AlgebraByXModAlgebra"
-         Arg="X0" />
-   <Oper Name="XModAlgebraByCat1Algebra"
-         Arg="C" />
-<Description> 
-These operations are used for constructing a cat<M>^{1}</M>-algebra 
-from a given crossed module, and conversely.
-</Description>
-</ManSection> 
-
-<Example>
-<![CDATA[
-gap> CXM := Cat1AlgebraByXModAlgebra( XM );
-[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
-gap> X3 := XModAlgebraByCat1Algebra( C3 ); 
-[Algebra( GF(2), [ <zero> of ..., <zero> of ..., <zero> of ... 
- ] )->Algebra( GF(2), 
-[ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ] )]
-gap> Display( X3 ); 
-
-Crossed module [..->..] :- 
-: Source algebra has generators:
-  [ <zero> of ..., <zero> of ..., <zero> of ... ]
-: Range algebra has generators:
-  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
-: Boundary homomorphism maps source generators to:
-  [ <zero> of ..., <zero> of ..., <zero> of ... ]
-]]>
-</Example>
-
+<P/> 
 Since all of these operations are linked to the functions 
 <Ref Oper="Cat1Algebra"/> and <Ref Oper="XModAlgebra"/>, 
 they can be permormed by calling these two functions. 
 We may also use the function <Ref Oper="Cat1Algebra"/> 
 instead of the operation <Ref Oper="Cat1AlgebraSelect"/>.
+
+<ManSection>
+   <Oper Name="Cat1AlgebraOfXModAlgebra"
+         Arg="X0" />
+   <Oper Name="PreCat1AlgebraOfPreXModAlgebra"
+         Arg="X0" />
+<Description> 
+These operations are used for constructing a cat<M>^{1}</M>-algebra 
+from a given crossed module of algebras.
+</Description>
+</ManSection> 
+
+<Example>
+<![CDATA[
+gap> CXM := Cat1AlgebraOfXModAlgebra( XM );
+[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
+gap> Display( CXM );
+
+Cat1-algebra [..=>GF(2^2)[k4]] :- 
+:  range algebra has generators:
+  [ (Z(2)^0)*<identity> of ..., (Z(2)^0)*f1, (Z(2)^0)*f2 ]
+: tail homomorphism maps source generators to:
+: range embedding maps range generators to:
+  [ [ (Z(2)^0)*<identity> of ..., <zero> of ... ], 
+  [ (Z(2)^0)*f1, <zero> of ... ], [ (Z(2)^0)*f2, <zero> of ... ] ]
+: kernel has generators:
+  [ [ <zero> of ..., <zero> of ... ], 
+  [ <zero> of ..., (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^
+        0)*f1*f2 ], 
+  [ <zero> of ..., (Z(2^2))*<identity> of ...+(Z(2^2))*f1+(Z(2^2))*f2+(
+        Z(2^2))*f1*f2 ], 
+  [ <zero> of ..., (Z(2^2)^2)*<identity> of ...+(Z(2^2)^2)*f1+(Z(2^2)^2)*f2+(
+        Z(2^2)^2)*f1*f2 ] ]
+]]>
+</Example>
+
+<ManSection>
+   <Oper Name="XModAlgebraOfCat1Algebra"
+         Arg="C" />
+   <Oper Name="PreXModAlgebraOfPreCat1Algebra"
+         Arg="C" />
+<Description> 
+These operations are used for constructing a crossed module of algebras 
+from a given cat<M>^{1}</M>-algebra.
+</Description>
+</ManSection> 
+
+<Example>
+<![CDATA[
+gap> X3 := XModAlgebraOfCat1Algebra( C3 ); 
+[ <algebra of dimension 3 over GF(2)> -> <algebra of dimension 3 over GF(2)> ]
+gap> Display( X3 ); 
+
+Crossed module [..->..] :- 
+: Source algebra has generators:
+  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
+  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
+: Range algebra has generators:
+  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3), (Z(2)^0)*(1,3,2) ]
+: Boundary homomorphism maps source generators to:
+  [ <zero> of ..., <zero> of ..., <zero> of ... ]
+]]>
+</Example>
 
 </Section>
 

--- a/doc/convert.xml
+++ b/doc/convert.xml
@@ -1,0 +1,89 @@
+<!-- ------------------------------------------------------------------- -->
+<!--                                                                     -->
+<!--  convert.xml          XModAlg documentation              Z. Arvasi  -->
+<!--                                                        & A. Odabas  -->
+<!--  Copyright (C) 2014-2018, Z. Arvasi & A. Odabas,                    --> 
+<!--  Osmangazi University, Eskisehir, Turkey                            --> 
+<!--                                                                     -->
+<!-- ------------------------------------------------------------------- -->
+
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Chapter Label="chap-convert">
+
+<Heading>Conversion between cat1-algebras and crossed modules</Heading>
+
+<Section> 
+
+<Heading>Equivalent Categories</Heading> 
+
+The categories <M>\mathbf{Cat1Alg}</M> (cat<M>^{1}</M>-algebras) 
+and <M>\mathbf{XModAlg}</M> (crossed modules) 
+are naturally equivalent <Cite Key="ellis1"/>.  
+This equivalence is outlined in what follows. 
+For a given crossed module <M>(\partial : A \rightarrow R)</M> 
+we can construct the semidirect product <M>R\ltimes A</M>
+thanks to the action of <M>R</M> on <M>A</M>. 
+If we define <M>t,h : R\ltimes A \rightarrow R</M> 
+and <M>e : R \rightarrow R \ltimes A</M> by 
+<Display>
+t(r,a) = r, \qquad 
+h(r,a) = r+\partial(a), \qquad 
+e(r) = (r,0), 
+</Display>
+respectively, then 
+<M>\mathcal{C} = (e;t,h : R \ltimes A \rightarrow R)</M> 
+is a cat<M>^{1}-</M>algebra.
+<P/> 
+Conversely, for a given cat<M>^{1}</M>-algebra 
+<M>\mathcal{C}=(e;t,h : A \rightarrow R)</M>, 
+the map <M>\partial : \ker t \rightarrow R</M> is a crossed module, 
+where the action is multiplication action and 
+<M>\partial</M> is the restriction of <M>h</M> to <M>\ker t</M>. 
+
+<ManSection>
+   <Oper Name="PreCat1ByPreXMod"
+         Arg="X0" />
+   <Oper Name="PreXModAlgebraByPreCat1Algebra"
+         Arg="C" />
+   <Oper Name="Cat1AlgebraByXModAlgebra"
+         Arg="X0" />
+   <Oper Name="XModAlgebraByCat1Algebra"
+         Arg="C" />
+<Description> 
+These operations are used for constructing a cat<M>^{1}</M>-algebra 
+from a given crossed module, and conversely.
+</Description>
+</ManSection> 
+
+<Example>
+<![CDATA[
+gap> CXM := Cat1AlgebraByXModAlgebra( XM );
+[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
+gap> X3 := XModAlgebraByCat1Algebra( C3 ); 
+[Algebra( GF(2), [ <zero> of ..., <zero> of ..., <zero> of ... 
+ ] )->Algebra( GF(2), 
+[ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
+  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ] )]
+gap> Display( X3 ); 
+
+Crossed module [..->..] :- 
+: Source algebra has generators:
+  [ <zero> of ..., <zero> of ..., <zero> of ... ]
+: Range algebra has generators:
+  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
+  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
+: Boundary homomorphism maps source generators to:
+  [ <zero> of ..., <zero> of ..., <zero> of ... ]
+]]>
+</Example>
+
+Since all of these operations are linked to the functions 
+<Ref Oper="Cat1Algebra"/> and <Ref Oper="XModAlgebra"/>, 
+they can be permormed by calling these two functions. 
+We may also use the function <Ref Oper="Cat1Algebra"/> 
+instead of the operation <Ref Oper="Cat1AlgebraSelect"/>.
+
+</Section>
+
+</Chapter>

--- a/lib/alg2map.gi
+++ b/lib/alg2map.gi
@@ -321,7 +321,7 @@ function( src, rng, srchom, rnghom )
     else
         nsrc := "[..]";
     fi;
-    if ( HasName( Source(rng) )and HasName( Range(rng) ) ) then
+    if ( HasName( Source(rng) ) and HasName( Range(rng) ) ) then
         nrng := Name( rng );
     else
         nrng := "[..]";

--- a/lib/alg2obj.gd
+++ b/lib/alg2obj.gd
@@ -90,6 +90,8 @@ DeclareOperation( "IsSubCat1Algebra", [ Is2dAlgebraObject, Is2dAlgebraObject ] )
 
 DeclareOperation( "PreCat1AlgebraObj",
     [ IsAlgebraHomomorphism, IsAlgebraHomomorphism, IsAlgebraHomomorphism ] );
+DeclareOperation( "PreCat1AlgebraByTailHeadEmbedding",
+    [ IsAlgebraHomomorphism, IsAlgebraHomomorphism, IsAlgebraHomomorphism ] );
 DeclareAttribute( "Equivalence", IsPreCat1Algebra );
 DeclareAttribute( "HeadMap", IsPreCat1Algebra );
 DeclareAttribute( "TailMap", IsPreCat1Algebra );

--- a/lib/alg2obj.gd
+++ b/lib/alg2obj.gd
@@ -102,7 +102,6 @@ DeclareGlobalFunction( "PreCat1Algebra" );
 
 DeclareProperty( "IsCat1Algebra", Is2dAlgebra );
 
-DeclareOperation( "PreXModAlgebraByPreCat1Algebra", [ IsPreCat1Algebra ] );
 DeclareAttribute( "Equivalence", IsPreCat1Algebra );
 DeclareAttribute( "SourceForEquivalence", IsCat1Algebra );
 DeclareAttribute( "BoundaryForEquivalence", IsCat1Algebra );
@@ -110,10 +109,11 @@ DeclareFilter( "IsEquivalenceHead", IsCat1Algebra );
 DeclareFilter( "IsEquivalenceTail", IsCat1Algebra );
 DeclareFilter( "IsXModAlgebraConst", IsCat1Algebra );
 DeclareAttribute( "XModAlgebraConst", IsCat1Algebra );
+
+DeclareAttribute( "PreXModAlgebraOfPreCat1Algebra", IsPreCat1Algebra );
+DeclareAttribute( "PreCat1AlgebraOfPreXModAlgebra", IsPreXModAlgebra );
 DeclareAttribute( "XModAlgebraOfCat1Algebra", IsPreCat1Algebra );
-DeclareOperation( "XModAlgebraByCat1Algebra", [ IsPreCat1Algebra ] );
 DeclareAttribute( "Cat1AlgebraOfXModAlgebra", IsPreXModAlgebra );
-DeclareOperation( "Cat1AlgebraByXModAlgebra", [ IsPreXModAlgebra ] );
 DeclareOperation( "EquivalenceTail", [ IsEquivalenceTail ] );
 DeclareOperation( "EquivalenceHead", [ IsEquivalenceHead ] );
 DeclareOperation( "SDproduct", [ Is2dAlgebraObject ] );

--- a/lib/alg2obj.gi
+++ b/lib/alg2obj.gi
@@ -1237,7 +1237,7 @@ function( C, R, S )
     t := RestrictionMappingAlgebra( Ct, R, S );
     h := RestrictionMappingAlgebra( Ch, R, S );
     e := RestrictionMappingAlgebra( Ce, S, R );
-    CC := PreCat1Obj( t, h, e );
+    CC := PreCat1AlgebraByTailHeadEmbedding( t, h, e );
     if not ( C = CC ) then
         SetParent( CC, C );
     fi;
@@ -1498,10 +1498,10 @@ InstallGlobalFunction( PreCat1Algebra, function( arg )
     # two homomorphisms and an embedding
     elif ( ( nargs=3 ) and
            ForAll( arg, a -> IsAlgebraHomomorphism( a ) ) ) then
-        return PreCat1Obj( arg[1], arg[2], arg[3] );
+        return PreCat1AlgebraByTailHeadEmbedding( arg[1], arg[2], arg[3] );
     fi;
     # alternatives not allowed
-    Error( "standard usage: PreCat1Algebra( tail, head [,embed] );" );
+    Error( "standard usage: PreCat1Algebra( tail, head [,embedding] );" );
 end );
 
 #############################################################################
@@ -1791,9 +1791,9 @@ end );
 
 #############################################################################
 ##
-#M  PreCat1Obj
+#M  PreCat1AlgebraByTailHeadEmbedding
 ##
-InstallOtherMethod( PreCat1Obj,
+InstallMethod( PreCat1AlgebraByTailHeadEmbedding,
     "cat1-algebra from tail, head and embedding", true, 
     [ IsAlgebraHomomorphism, IsAlgebraHomomorphism, IsAlgebraHomomorphism ], 0,
 function( t, h, e )
@@ -1845,16 +1845,16 @@ function( et, eh )
     local  G, gG, R, t, h, e;
 
     if not ( IsEndoMapping( et ) and IsEndoMapping( eh ) ) then
-       # Error( "et, eh must both be group endomorphisms" );
-       return fail;
+        Info( InfoXModAlg, 1, "et, eh must both be group endomorphisms" );
+        return fail;
     fi;
     if not ( Source( et ) = Source( eh ) ) then
-      #  Error( "et and eh must have same source" );
+        Info( InfoXModAlg, 1, "et and eh must have same source" );
         return fail;
     fi;
     G := Source( et );
     if not ( Image( et ) = Image( eh ) ) then
-       # Error( "et and eh must have same image" );
+        Info( InfoXModAlg, 1, "et and eh must have same image" );
         return fail;
     fi;
     R := Image( et );
@@ -1862,7 +1862,7 @@ function( et, eh )
     t := AlgebraHomomorphismByImages( G, R, gG, List( gG, g->Image( et, g ) ) );
     h := AlgebraHomomorphismByImages( G, R, gG, List( gG, g->Image( eh, g ) ) );
     e := InclusionMappingAlgebra( G, R );
-    return PreCat1Obj( t, h, e );
+    return PreCat1AlgebraByTailHeadEmbedding( t, h, e );
 end );
 
 #############################################################################

--- a/lib/alg2obj.gi
+++ b/lib/alg2obj.gi
@@ -1647,7 +1647,7 @@ function( gf, size, gpnum, num )
            G, genG, M, L, genR, R, t, kert, e, h, imt, imh, C1A, XC, elA;
 
     maxsize := CAT1ALG_LIST_MAX_SIZE;   
-    usage := "Usage: Cat1Algebra( gf, gpsize, gpnum, num );";
+    usage := "Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );";
     
     # if ( CAT1ALG_LIST_LOADED = false ) then    
         ReadPackage( "xmodalg", "lib/cat1algdata.g" );
@@ -1656,8 +1656,8 @@ function( gf, size, gpnum, num )
     usage_list1 := Set(CAT1ALG_LIST, i -> i[1]);
     if not gf in usage_list1 then
       Print( "|--------------------------------------------------------| \n" );   
-      Print( "| ",gf," is invalid number for Galois Field (gf) \t \t | \n");
-      Print( "| Possible numbers for the gf in the Data : \t \t | \n");
+      Print( "| ",gf," is invalid number for Galois Field (GFnum) \t \t | \n");
+      Print( "| Possible numbers for GFnum in the Data : \t \t | \n");
       Print( "|--------------------------------------------------------| \n" ); 
       Print( " ",usage_list1," \n");
       Print( usage, "\n" );
@@ -2025,47 +2025,9 @@ end );
 
 #############################################################################
 ##
-#M  SDproduct. . . . convert a pre-crossed module to a pre-cat1-algebra
+#M  PreXModAlgebraOfPreCat1Algebra
 ##
-InstallMethod( SDproduct,
-    "convert a pre-crossed module to a pre-cat1-algebra", true, 
-    [ Is2dAlgebraObject ], 0,
-function( C1A )
-
-    local  h, t, list, kt, kh, uzkt, uzkh, a, i, j, p, q, t1, m, t2, t3, s, x;
-
-    if not ( IsPreCat1AlgebraObj( C1A ) and IsPreCat1Algebra( C1A ) ) then
-        return false;
-    fi;    
-    h := HeadMap( C1A );
-    t := TailMap( C1A );
-    list:=[];;
-    kt := Kernel(t);
-    kh := Kernel(h);
-    uzkt := Size(kt);
-    uzkh := Size(kh);
-    a := XModAlgebraAction(h);
-    for i in [1..uzkt] do
-        p := kt[i];
-        for j in [1..uzkh] do   
-            q := kh[j];
-            t1 := p[2]*q[2];
-            m := [p[2],q[1]];
-            t2 := Image(a,m);
-            s := [p[1],q[2]];
-            t3 := Image(a,s);
-            x := [(p[1]*q[1]),t1+t2+t3];            
-            Add( list, x );
-        od;
-    od;
-    return list;
-end ); 
-
-#############################################################################
-##
-#M  PreXModAlgebraByPreCat1Algebra
-##
-InstallMethod( PreXModAlgebraByPreCat1Algebra, true, [ IsPreCat1Algebra ], 0,
+InstallMethod( PreXModAlgebraOfPreCat1Algebra, true, [ IsPreCat1Algebra ], 0,
 function( C1A )
  
     local  usage, A, B, C, bdy, gA, im, sbdy, PM,act,R,s,t;
@@ -2096,14 +2058,14 @@ end );
 
 ##############################################################################
 ##
-#M  XModAlgebraByCat1Algebra
+#M  XModAlgebraOfCat1Algebra
 ##
-InstallMethod( XModAlgebraByCat1Algebra, "generic method for cat1-algebras",
+InstallMethod( XModAlgebraOfCat1Algebra, "generic method for cat1-algebras",
     true, [ IsPreCat1Algebra ], 0,
 function( C1 )
 
     local  X1;
-    X1 := PreXModAlgebraByPreCat1Algebra( C1 );
+    X1 := PreXModAlgebraOfPreCat1Algebra( C1 );
     if not IsCat1Algebra( C1 ) then
         Print( "Warning : C is only Pre-cat1-algebra\n" );        
     fi;    
@@ -2115,19 +2077,9 @@ end );
 
 ##############################################################################
 ##
-#M  XModAlgebraOfCat1Algebra
+#M  Cat1AlgebraOfXModAlgebra
 ##
-InstallMethod( XModAlgebraOfCat1Algebra, "generic method for cat1-algebras",
-    true, [ IsPreCat1Algebra ], 0,
-function( C1 )
-    return XModAlgebraByCat1Algebra( C1 );
-end );
-
-##############################################################################
-##
-#M  Cat1AlgebraByXModAlgebra
-##
-InstallMethod( Cat1AlgebraByXModAlgebra, "generic method for crossed modules",
+InstallMethod( Cat1AlgebraOfXModAlgebra, "generic method for crossed modules",
     true, [ IsPreXModAlgebra ], 0,
 function( X1 )
 
@@ -2140,16 +2092,6 @@ function( X1 )
     SetXModAlgebraOfCat1Algebra( C1, X1 );
     SetCat1AlgebraOfXModAlgebra( X1, C1 );
     return C1;
-end );
-
-##############################################################################
-##
-#M  Cat1AlgebraOfXModAlgebra
-##
-InstallMethod( Cat1AlgebraOfXModAlgebra, "generic method for cat1-algebras",
-    true, [ IsPreXModAlgebra ], 0,
-function( X1 )
-    return Cat1AlgebraByXModAlgebra( X1 );
 end );
 
 ##############################################################################

--- a/makedoc.g
+++ b/makedoc.g
@@ -9,7 +9,7 @@ LoadPackage( "AutoDoc" );
 AutoDoc( rec( 
     scaffold := rec(
         ## MainPage := false, 
-        includes := [ "intro.xml", "cat1.xml", "xmod.xml" ],
+        includes := [ "intro.xml", "cat1.xml", "xmod.xml", "convert.xml" ],
         bib := "bib.xml", 
         gapdoc_latex_options := rec( EarlyExtraPreamble := """
             \usepackage[all]{xy} 

--- a/tst/cat1.tst
+++ b/tst/cat1.tst
@@ -56,7 +56,7 @@ gap> Print( mgiRA, "\n" );
   [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3) ] ], 
   [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
   [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,3,2) ] ] ]
-gap> C4 := PreCat1Obj( homAR[6], homAR[6], homRA[8] );
+gap> C4 := PreCat1AlgebraByTailHeadEmbedding( homAR[6], homAR[6], homRA[8] );
 [AlgebraWithOne( GF(2), [ (Z(2)^0)*(1,2,3)(4,5) ] ) -> AlgebraWithOne( GF(2), 
 [ (Z(2)^0)*(1,2,3) ] )]
 gap> IsCat1Algebra( C4 );

--- a/tst/cat1.tst
+++ b/tst/cat1.tst
@@ -89,11 +89,11 @@ gap> ############################
 gap> ## Chapter 2,  Section 2.1.3
 gap> C := Cat1AlgebraSelect( 11 );
 |--------------------------------------------------------|
-| 11 is invalid number for Galois Field (gf)             |
-| Possible numbers for the gf in the Data :              |
+| 11 is invalid number for Galois Field (GFnum)             |
+| Possible numbers for GFnum in the Data :              |
 |--------------------------------------------------------|
  [ 2, 3, 4, 5, 7 ]
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 fail
 gap> C := Cat1AlgebraSelect( 4, 12 );
 |--------------------------------------------------------|
@@ -101,7 +101,7 @@ gap> C := Cat1AlgebraSelect( 4, 12 );
 | Possible numbers for the gpsize for GF(4) in the Data: |
 |--------------------------------------------------------|
  [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 fail
 gap> C := Cat1AlgebraSelect( 2, 6, 3 );
 |--------------------------------------------------------|
@@ -109,7 +109,7 @@ gap> C := Cat1AlgebraSelect( 2, 6, 3 );
 | Possible numbers for the gpnum in the Data :           |
 |--------------------------------------------------------|
  [ 1, 2 ]
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 fail
 gap> C := Cat1AlgebraSelect( 2, 6, 2 );
 There are 4 cat1-structures for the algebra GF(2)_c6.
@@ -120,7 +120,7 @@ There are 4 cat1-structures for the algebra GF(2)_c6.
 | -----         [ 2, 14 ]               [ 2, 14 ]        |
 | -----         [ 2, 50 ]               [ 2, 50 ]        |
 |--------------------------------------------------------|
-Usage: Cat1Algebra( gf, gpsize, gpnum, num );
+Usage: Cat1Algebra( GFnum, gpsize, gpnum, num );
 Algebra has generators [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3)(4,5) ]
 4
 gap> C0 := Cat1AlgebraSelect( 4, 6, 2, 2 );
@@ -282,39 +282,6 @@ gap> IsInjective( m );
 true
 gap> IsBijective( m );
 false
-gap> ## Chapter 2,  Section 2.3.1
-gap> CXM := Cat1AlgebraByXModAlgebra( XM );
-[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
-gap> Display( CXM );
-
-Cat1-algebra [..=>GF(2^2)[k4]] :- 
-:  range algebra has generators:
-  [ (Z(2)^0)*<identity> of ..., (Z(2)^0)*f1, (Z(2)^0)*f2 ]
-: tail homomorphism maps source generators to:
-: range embedding maps range generators to:
-  [ [ (Z(2)^0)*<identity> of ..., <zero> of ... ], 
-  [ (Z(2)^0)*f1, <zero> of ... ], [ (Z(2)^0)*f2, <zero> of ... ] ]
-: kernel has generators:
-  [ [ <zero> of ..., <zero> of ... ], 
-  [ <zero> of ..., (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^
-        0)*f1*f2 ], 
-  [ <zero> of ..., (Z(2^2))*<identity> of ...+(Z(2^2))*f1+(Z(2^2))*f2+(
-        Z(2^2))*f1*f2 ], 
-  [ <zero> of ..., (Z(2^2)^2)*<identity> of ...+(Z(2^2)^2)*f1+(Z(2^2)^2)*f2+(
-        Z(2^2)^2)*f1*f2 ] ]
-
-gap> X3 := XModAlgebraByCat1Algebra( C3 ); 
-[ <algebra of dimension 3 over GF(2)> -> <algebra of dimension 3 over GF(2)> ]
-gap> Display( X3 ); 
-
-Crossed module [..->..] :- 
-: Source algebra has generators:
-  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
-: Range algebra has generators:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3), (Z(2)^0)*(1,3,2) ]
-: Boundary homomorphism maps source generators to:
-  [ <zero> of ..., <zero> of ..., <zero> of ... ]
 
 gap> SetInfoLevel( InfoXModAlg, saved_infolevel_xmodalg );; 
 gap> STOP_TEST( "cat1.tst", 10000 );

--- a/tst/convert.tst
+++ b/tst/convert.tst
@@ -1,0 +1,70 @@
+#############################################################################
+##
+#W  convert.tst             XModAlg test files          Z. Arvasi - A. Odabas 
+## 
+gap> START_TEST( "XModAlg package: convert.tst" );
+gap> saved_infolevel_xmodalg := InfoLevel( InfoXModAlg );; 
+gap> SetInfoLevel( InfoXModAlg, 0 );
+
+gap> ## make convert.tst independent of cat1.tst and xmod.tst 
+gap> Ak4 := GroupRing( GF(5), DihedralGroup(4) );;
+gap> SetName( Ak4, "GF5[k4]" );
+gap> IAk4 := AugmentationIdeal( Ak4 );;
+gap> SetName( IAk4, "I(GF5[k4])" );
+gap> XIAk4 := XModAlgebraByIdeal( Ak4, IAk4 );;
+gap> G := SmallGroup( 4, 2 );;
+gap> F := GaloisField( 4 );;
+gap> R := GroupRing( F, G );;
+gap> SetName( R, "GF(2^2)[k4]" ); 
+gap> e5 := Elements(R)[5];; 
+gap> S := Subalgebra( R, [e5] );; 
+gap> SetName( S, "<e5>" );
+gap> RS := Cartesian( R, S );; 
+gap> SetName( RS, "GF(2^2)[k4] x <e5>" ); 
+gap> act := AlgebraAction( R, RS, S );;
+gap> bdy := AlgebraHomomorphismByFunction( S, R, r->r );;
+gap> IsAlgebraAction( act );; 
+gap> IsAlgebraHomomorphism( bdy );; 
+gap> XM := PreXModAlgebraByBoundaryAndAction( bdy, act );;
+gap> IsXModAlgebra( XM );;
+gap> ############################ 
+gap> ## Chapter 4,  Section 4.1.1
+gap> CXM := Cat1AlgebraByXModAlgebra( XM );
+[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
+gap> Display( CXM );
+
+Cat1-algebra [..=>GF(2^2)[k4]] :- 
+:  range algebra has generators:
+  [ (Z(2)^0)*<identity> of ..., (Z(2)^0)*f1, (Z(2)^0)*f2 ]
+: tail homomorphism maps source generators to:
+: range embedding maps range generators to:
+  [ [ (Z(2)^0)*<identity> of ..., <zero> of ... ], 
+  [ (Z(2)^0)*f1, <zero> of ... ], [ (Z(2)^0)*f2, <zero> of ... ] ]
+: kernel has generators:
+  [ [ <zero> of ..., <zero> of ... ], 
+  [ <zero> of ..., (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^
+        0)*f1*f2 ], 
+  [ <zero> of ..., (Z(2^2))*<identity> of ...+(Z(2^2))*f1+(Z(2^2))*f2+(
+        Z(2^2))*f1*f2 ], 
+  [ <zero> of ..., (Z(2^2)^2)*<identity> of ...+(Z(2^2)^2)*f1+(Z(2^2)^2)*f2+(
+        Z(2^2)^2)*f1*f2 ] ]
+
+gap> X3 := XModAlgebraByCat1Algebra( C3 ); 
+[ <algebra of dimension 3 over GF(2)> -> <algebra of dimension 3 over GF(2)> ]
+gap> Display( X3 ); 
+
+Crossed module [..->..] :- 
+: Source algebra has generators:
+  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
+  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
+: Range algebra has generators:
+  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3), (Z(2)^0)*(1,3,2) ]
+: Boundary homomorphism maps source generators to:
+  [ <zero> of ..., <zero> of ..., <zero> of ... ]
+
+gap> SetInfoLevel( InfoXModAlg, saved_infolevel_xmodalg );; 
+gap> STOP_TEST( "convert.tst", 10000 );
+
+############################################################################
+##
+#E  convert.tst  . . . . . . . . . . . . . . . . . . . . . . . . . ends here

--- a/tst/convert.tst
+++ b/tst/convert.tst
@@ -27,9 +27,10 @@ gap> IsAlgebraAction( act );;
 gap> IsAlgebraHomomorphism( bdy );; 
 gap> XM := PreXModAlgebraByBoundaryAndAction( bdy, act );;
 gap> IsXModAlgebra( XM );;
+
 gap> ############################ 
 gap> ## Chapter 4,  Section 4.1.1
-gap> CXM := Cat1AlgebraByXModAlgebra( XM );
+gap> CXM := Cat1AlgebraOfXModAlgebra( XM );
 [GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
 gap> Display( CXM );
 
@@ -49,7 +50,7 @@ Cat1-algebra [..=>GF(2^2)[k4]] :-
   [ <zero> of ..., (Z(2^2)^2)*<identity> of ...+(Z(2^2)^2)*f1+(Z(2^2)^2)*f2+(
         Z(2^2)^2)*f1*f2 ] ]
 
-gap> X3 := XModAlgebraByCat1Algebra( C3 ); 
+gap> X3 := XModAlgebraOfCat1Algebra( C3 ); 
 [ <algebra of dimension 3 over GF(2)> -> <algebra of dimension 3 over GF(2)> ]
 gap> Display( X3 ); 
 

--- a/tst/testing.g
+++ b/tst/testing.g
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-#W  testing.g, 30/10/17          XModAlg test files     Z. Arvasi - A. Odabas 
+#W  testing.g                XModAlg test files         Z. Arvasi - A. Odabas 
 ##
 #############################################################################
 
@@ -12,7 +12,7 @@ TestXModAlg := function( pkgname )
     pkgdir := DirectoriesPackageLibrary( pkgname, "tst" );
     # Arrange chapters as required
     testfiles := 
-        [ "xmod.tst", "cat1.tst" ];
+        [ "cat1.tst", "xmod.tst", "convert.tst" ];
     testresult := true;
     for ff in testfiles do
         fn := Filename( pkgdir, ff );


### PR DESCRIPTION
Conversion functions (xmod algebra) <--> (cat1-algebra) now split off in the manual to a separate chapter; ditto tests.  Names now use 'Of', not 'By'. 