### PR TITLE
Add a bunch of trivial implications

### DIFF
--- a/lib/alg2map.gd
+++ b/lib/alg2map.gd
@@ -15,6 +15,8 @@ BindGlobal( "Family2dAlgebraMorphism",
 
 DeclareProperty( "IsPreXModAlgebraMorphism", Is2dAlgebraMorphism );
 DeclareProperty( "IsXModAlgebraMorphism", Is2dAlgebraMorphism );
+InstallTrueMethod(Is2dAlgebraMorphism, IsPreXModAlgebraMorphism);
+InstallTrueMethod(Is2dAlgebraMorphism, IsXModAlgebraMorphism);
 
 DeclareRepresentation( "Is2dAlgebraMorphismRep", 
     Is2dAlgebraMorphism and IsAttributeStoringRep,
@@ -40,6 +42,8 @@ DeclareOperation( "Cat1AlgebraMorphismByHoms",
 
 DeclareProperty( "IsPreCat1AlgebraMorphism", Is2dAlgebraMorphism );
 DeclareProperty( "IsCat1AlgebraMorphism", Is2dAlgebraMorphism );
+InstallTrueMethod(Is2dAlgebraMorphism, IsPreCat1AlgebraMorphism);
+InstallTrueMethod(Is2dAlgebraMorphism, IsCat1AlgebraMorphism);
 
 
 


### PR DESCRIPTION
This makes various "hidden" implications created by DeclareProperty explicit, thus fixing a bunch of warnings that show up if one starts the upcoming GAP 4.11 with the `-N` command line option, and then loads this package.

For some information on the background of this, see also <https://github.com/gap-system/gap/issues/1649> and <https://github.com/gap-system/gap/issues/2336>