### PR TITLE
Build the nq package for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   global:
     - GAPROOT=gaproot
     - COVDIR=coverage
+    - GAP_PKGS_TO_BUILD="nq"
 
 addons:
   apt_packages:


### PR DESCRIPTION
The Travis tests currently fail - as it is, the `XModAlg` package cannot even load, because the `nq` executable is not available.

This resolves the problem.