### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/doc/cat1.xml
+++ b/doc/cat1.xml
@@ -115,10 +115,8 @@ These are the seven main attributes of a pre-cat<M>^{1}</M>-algebra.
 
 <Example>
 <![CDATA[
-gap> Ac6 := GroupRing( GF(2), Group( (1,2,3)(4,5) ) );
-<algebra-with-one over GF(2), with 1 generators>
-gap> Rc3 := GroupRing( GF(2), Group( (1,2,3) ) );
-<algebra-with-one over GF(2), with 1 generators>
+gap> Ac6 := GroupRing( GF(2), Group( (1,2,3)(4,5) ) );;
+gap> Rc3 := GroupRing( GF(2), Group( (1,2,3) ) );;
 gap> homAR := AllHomsOfAlgebras( Ac6, Rc3 );;
 gap> mgiAR := List( homAR, h -> MappingGeneratorsImages(h) );;
 gap> Print( mgiAR, "\n" );

--- a/doc/xmod.xml
+++ b/doc/xmod.xml
@@ -211,8 +211,7 @@ of a given crossed module.
 <![CDATA[
 gap> e4 := Elements( IAk4 )[4];
 (Z(5)^0)*<identity> of ...+(Z(5)^0)*f1+(Z(5)^2)*f2+(Z(5)^2)*f1*f2
-gap> Je4 := Ideal( IAk4, [e4] );
-<two-sided ideal in I(GF5[k4]), (1 generators)>
+gap> Je4 := Ideal( IAk4, [e4] );;
 gap> Size( Je4 );
 5
 gap> SetName( Je4, "<e4>" ); 
@@ -261,8 +260,7 @@ gap> Size( R );
 gap> SetName( R, "GF(2^2)[k4]" ); 
 gap> e5 := Elements( R )[5]; 
 (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2
-gap> S := Subalgebra( R, [e5] ); 
-<algebra over GF(2^2), with 1 generators>
+gap> S := Subalgebra( R, [e5] );;
 gap> SetName( S, "<e5>" );
 gap> RS := Cartesian( R, S );; 
 gap> SetName( RS, "GF(2^2)[k4] x <e5>" ); 

--- a/tst/cat1.tst
+++ b/tst/cat1.tst
@@ -29,10 +29,8 @@ gap> XM := PreXModAlgebraByBoundaryAndAction( bdy, act );;
 gap> IsXModAlgebra( XM );;
 gap> ############################ 
 gap> ## Chapter 2,  Section 2.1.2
-gap> Ac6 := GroupRing( GF(2), Group( (1,2,3)(4,5) ) );
-<algebra-with-one over GF(2), with 1 generators>
-gap> Rc3 := GroupRing( GF(2), Group( (1,2,3) ) );
-<algebra-with-one over GF(2), with 1 generators>
+gap> Ac6 := GroupRing( GF(2), Group( (1,2,3)(4,5) ) );;
+gap> Rc3 := GroupRing( GF(2), Group( (1,2,3) ) );;
 gap> homAR := AllHomsOfAlgebras( Ac6, Rc3 );;
 gap> mgiAR := List( homAR, h -> MappingGeneratorsImages(h) );;
 gap> Print( mgiAR, "\n" );

--- a/tst/xmod.tst
+++ b/tst/xmod.tst
@@ -49,8 +49,7 @@ gap> Print( KnownAttributesOfObject(XIAk4), "\n" );
 gap> ## Chapter 3,  Section 3.1.3
 gap> e4 := Elements( IAk4 )[4];
 (Z(5)^0)*<identity> of ...+(Z(5)^0)*f1+(Z(5)^2)*f2+(Z(5)^2)*f1*f2
-gap> Je4 := Ideal( IAk4, [e4] );
-<two-sided ideal in I(GF5[k4]), (1 generators)>
+gap> Je4 := Ideal( IAk4, [e4] );;
 gap> Size( Je4 );
 5
 gap> SetName( Je4, "<e4>" ); 
@@ -81,8 +80,7 @@ gap> Size( R );
 gap> SetName( R, "GF(2^2)[k4]" ); 
 gap> e5 := Elements( R )[5]; 
 (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2
-gap> S := Subalgebra( R, [e5] ); 
-<algebra over GF(2^2), with 1 generators>
+gap> S := Subalgebra( R, [e5] );;
 gap> SetName( S, "<e5>" );
 gap> RS := Cartesian( R, S );; 
 gap> SetName( RS, "GF(2^2)[k4] x <e5>" ); 


### PR DESCRIPTION
~(Note: the Travis tests will fail until PR #35 is merged and this PR is rebased.)~

In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` in GAP for `CyclicGroup(3);` is currently `<pc group of size 3 with 1 generators>`, whereas it will soon correctly show `<pc group of size 3 with 1 generator>`.

The changes in this PR maintain the backwards compatibility of this package with GAP, and it ensures that the upcoming changes to GAP on this topic do not affect the package either.

See gap-system/gap#3992 and gap-system/gap#4050 for more context.