### PR TITLE
Vspchom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # CHANGES to the 'XModAlg' package
 
 ## 1.18 -> 1.18dev (18/11/20) 
+ * (11/05/21) added lib/vspchom.gi as a temporary fix 
 
 ## 1.17 -> 1.18 (17/11/20) 
  * (07/08/20) fixed problem with Cat1AlgebraOfXModAlgebra 

--- a/lib/alg2obj.gi
+++ b/lib/alg2obj.gi
@@ -498,9 +498,9 @@ end );
 
 ##############################################################################
 ##
-#M  Size( <P> )  . . . . . . . . . . . . . . . . size for a pre-crossed module
+#M  Size( <P> )  . . . . . . . . . . . . . . . . . . . . size for a 2d-algebra
 ##
-InstallOtherMethod( Size, "generic method for a 2d-object",
+InstallOtherMethod( Size, "generic method for a 2d-algebra",
     [ Is2dAlgebraObject ], 0,
 function ( obj )
     return [ Size( Source(obj) ), Size( Range(obj) ) ];

--- a/lib/vspchom.gi
+++ b/lib/vspchom.gi
@@ -1,0 +1,62 @@
+##  This is a temporary file, created 11/5/21 
+##  it contains a fix to the following operation method 
+##  which was added to gapdev at that time. 
+##  So this file needs to be ReRead when XModAlg is loaded until such time 
+##  as the gapdev fix has become part of the standard distribution. 
+
+#############################################################################
+##
+#F  MakeImagesInfoLinearGeneralMappingByImages( <map> )
+##
+##  Provide the information for computing images, that is, set up
+##  the components `basispreimage', `imagesbasispreimage', `corelations'.
+##
+BindGlobal( "MakeImagesInfoLinearGeneralMappingByImages", function( map )
+    local preimage,
+          ech,
+	  mapi,
+          B;
+
+    preimage:= PreImagesRange( map );
+    mapi:= MappingGeneratorsImages( map );
+
+    if   Dimension( preimage ) = 0 then
+
+      # Set the entries explicitly.
+      map!.basispreimage       := Basis( preimage );
+      map!.corelations         := IdentityMat( Length( mapi[2] ),
+                                      LeftActingDomain( preimage ) );
+      map!.imagesbasispreimage := Immutable( [] );
+
+    elif IsGaussianRowSpace( Source( map ) ) then
+#T operation MakeImagesInfo( map, source )
+#T to leave this to the method selection ?
+#T or flag `IsFromGaussianSpace' ?
+
+      # The images of the basis vectors are obtained on
+      # forming the linear combinations of images of generators
+      # given by `ech.coeffs'.
+
+      ech:= SemiEchelonMatTransformation( mapi[1] );
+      map!.basispreimage       := SemiEchelonBasisNC(
+                                      preimage, ech.vectors );
+      map!.corelations         := Immutable( ech.relations );
+      map!.imagesbasispreimage := Immutable( ech.coeffs * mapi[2] );
+#T problem if mapi[2] is a basis and if this does not store that it is a small list!
+
+    else
+
+      # Delegate the work to the associated row space.
+      B:= Basis( preimage );
+      ech:= SemiEchelonMatTransformation( List( mapi[1],
+                     x -> Coefficients( B, x ) ) );
+      map!.basispreimage       := BasisNC( preimage,
+                                      List( ech.vectors,
+                                        x -> LinearCombination( B, x ) ) );
+      map!.corelations         := Immutable( ech.relations );
+      map!.imagesbasispreimage := Immutable( List( ech.coeffs,
+                                    x -> LinearCombination( mapi[2], x ) ) );
+
+    fi;
+end );
+

--- a/read.g
+++ b/read.g
@@ -2,9 +2,9 @@
 ##
 #W  read.g                 The XMODALG package               Zekeriya Arvasi
 #W                                                             & Alper Odabas
-##  version 1.18, 07/08/2020 
+##  version 1.19, 11/05/2021 
 ##
-#Y  Copyright (C) 2014-2020, Zekeriya Arvasi & Alper Odabas,  
+#Y  Copyright (C) 2014-2021, Zekeriya Arvasi & Alper Odabas,  
 ##
 
 ## read the actual code 
@@ -12,3 +12,5 @@ ReadPackage( "xmodalg", "lib/alg2obj.gi" );
 ReadPackage( "xmodalg", "lib/util.gi" );
 ReadPackage( "xmodalg", "lib/alg2map.gi" );  
 
+## temporary fix 
+RereadPackage( "xmodalg", "lib/vspchom.gi" ); 


### PR DESCRIPTION
A problem in the main library method for MakeImagesInfoLinearGeneralMappingByImages has been fixed in GAPdev and that fix has been included in the new XModAlg file lib/vspchom.gi.  This file can be removed again once the fix becomes available in the main GAP release. 