### PR TITLE
revised Cat1AlgebraOfXModAlgebra

### DIFF
--- a/doc/algebra.xml
+++ b/doc/algebra.xml
@@ -72,12 +72,12 @@ by multiplication to give the vector
 
 <Example>
 <![CDATA[
-gap> Ac6 := GroupRing( GF(5), Group( (1,2,3,4,5,6) ) );;
-gap> vecA := BasisVectors( Basis( Ac6 ) );; 
+gap> A5c6 := GroupRing( GF(5), Group( (1,2,3,4,5,6) ) );;
+gap> vecA := BasisVectors( Basis( A5c6 ) );; 
 gap> v := vecA[1] + vecA[3] + vecA[5];
 (Z(5)^0)*()+(Z(5)^0)*(1,3,5)(2,4,6)+(Z(5)^0)*(1,5,3)(2,6,4)
-gap> Ic6 := Ideal( Ac6, [v] );; 
-gap> act := AlgebraActionByMultiplication( Ac6, Ic6 );; 
+gap> I5c6 := Ideal( A5c6, [v] );; 
+gap> act := AlgebraActionByMultiplication( A5c6, I5c6 );; 
 gap> act2 := Image( act, vecA[2] );; 
 gap> Image( act2, v );
 (Z(5)^0)*(1,2,3,4,5,6)+(Z(5)^0)*(1,4)(2,5)(3,6)+(Z(5)^0)*(1,6,5,4,3,2)
@@ -96,7 +96,20 @@ When <M>R,S</M> are commutative algebras and <M>R</M> acts on <M>S</M>
 then we can form the semidirect product <M>R \ltimes S</M>, 
 where the product is given by: 
 <Display>
-(r,s)(r',s') ~=~ (rr',~ r \cdot s' + r' \cdot s + ss'). 
+(r_1,s_1)(r_2,s_2) ~=~ (r_1r_2,~ r_1 \cdot s_2 + r_2 \cdot s_1 + s_1s_2). 
+</Display> 
+
+It appears that this product is not associative! 
+<Display>
+(r_1,s_1)(r_2r_3,~ r_2 \cdot s_3 + r_3 \cdot s_2 + s_2s_3) 
+~=~ (r_1r_2r_3,~ (r_1r_2)\cdot s3 + (r_1r_3)\cdot s_2 
+                + (r_2r_3)\cdot s_1 + s_1s_2s_3 + r_1 \cdot (s_2s_3), 
+</Display> 
+but the last term differs in the alternative expansion: 
+<Display>
+(r_1r_2,~ r_1 \cdot s_2 + r_2 \cdot s_1 + s_1s_2)(r_3,s_3) 
+~=~ (r_1r_2r_3,~ (r_1r_2)\cdot s_3 + (r_1r_3)\cdot s_2 
+                + (r_2r_3)\cdot s_1 + s_1s_2s_3 + r_3 \cdot (s_1s_2). 
 </Display> 
 
 If <M>B_R, B_S</M> are the sets of basis vectors for <M>R</M> and <M>S</M> 
@@ -106,9 +119,9 @@ then <M>R \ltimes S</M> has basis
 </Display>
 with defining products 
 <Display>
-(r,0_S)(r',0_S) = (rr',0_S), \qquad 
+(r_1,0_S)(r_2,0_S) = (r_1r_2,0_S), \qquad 
 (r,0_S)(0_R,s) = (0_R,r \cdot s), \qquad 
-(0_R,s)(0_R,s') = (0_R,ss'). 
+(0_R,s_1)(0_R,s_2) = (0_R,s_1s_2). 
 </Display>
 Continuing the example above,
 </Description> 
@@ -116,7 +129,7 @@ Continuing the example above,
 
 <Example>
 <![CDATA[
-gap> P := SemidirectProductOfAlgebras( Ac6, act, Ic6 ); 
+gap> P := SemidirectProductOfAlgebras( A5c6, act, I5c6 ); 
 gap> Embedding( P, 1 );
 [ (Z(5)^0)*(), (Z(5)^0)*(1,2,3,4,5,6), (Z(5)^0)*(1,3,5)(2,4,6), 
   (Z(5)^0)*(1,4)(2,5)(3,6), (Z(5)^0)*(1,5,3)(2,6,4), (Z(5)^0)*(1,6,5,4,3,2) 
@@ -143,8 +156,73 @@ is a record with fields <C>P.action</C>; <C>P.algebras</C>;
 </Description> 
 </ManSection> 
 
-
 </Section>
 
+<Section Label="algebra-homomorphism-lists">
+
+<Heading>Lists of algebra homomorphisms</Heading> 
+
+<ManSection>
+   <Oper Name="AllAlgebraHomomorphisms"
+         Arg="A B" />
+   <Oper Name="AllBijectiveAlgebraHomomorphisms"
+         Arg="A B" />
+   <Oper Name="AllIdempotentAlgebraHomomorphisms"
+         Arg="A B" />
+<Description>
+These three operations list all the homomorphisms from <M>A</M> to <M>B</M> 
+of the specified type. 
+These lists can get very long, so the operations should only be used with 
+small algebras. 
+</Description> 
+</ManSection> 
+
+<Example>
+<![CDATA[
+gap> A2c6 := GroupRing( GF(2), Group( (1,2,3,4,5,6) ) );;
+gap> R2c3 := GroupRing( GF(2), Group( (7,8,9) ) );;
+gap> homAR := AllAlgebraHomomorphisms( A2c6, R2c3 );;
+gap> List( homAR, h -> MappingGeneratorsImages(h) );
+[ [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ <zero> of ... ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*() ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*()+(Z(2)^0)*(7,8,9) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(7,8,9)+(Z(2)^0)*(7,9,8) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*()+(Z(2)^0)*(7,9,8) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(7,8,9) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(7,8,9)+(Z(2)^0)*(7,9,8) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(7,9,8) ] ] ]
+gap> homRA := AllAlgebraHomomorphisms( R2c3, A2c6 );;
+gap> List( homRA, h -> MappingGeneratorsImages(h) );
+[ [ [ (Z(2)^0)*(7,8,9) ], [ <zero> of ... ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*() ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,3,5)(2,4,6) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)(2,6,4) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,5,3)(2,6,4) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*(1,3,5)(2,4,6) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)(2,6,4) ] 
+     ], [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*(1,5,3)(2,6,4) ] ] ]
+gap> bijAA := AllBijectiveAlgebraHomomorphisms( A2c6, A2c6 );;
+gap> List( bijAA, h -> MappingGeneratorsImages(h) );
+[ [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,4)(2,5)(3,6) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(1,4)(2,5)(3,6)+(Z(2)^0)*(1,5,3)(2,6,4) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(1,2,3,4,5,6) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*(1,2,3,4,5,6)+(Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)
+            (2,6,4) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)(2,6,4)+(Z(2)^0)*
+            (1,6,5,4,3,2) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(1,6,5,4,3,2) ] ] ]
+gap> ideAA := AllIdempotentAlgebraHomomorphisms( A2c6, A2c6 );; 
+gap> Length( ideAA );
+14
+]]>
+</Example>
+
+</Section> 
 
 </Chapter>

--- a/doc/cat1.xml
+++ b/doc/cat1.xml
@@ -110,39 +110,21 @@ are used with particular choices of algebra homomorphisms.
          Arg="C" />
 <Description> 
 These are the seven main attributes of a pre-cat<M>^{1}</M>-algebra. 
+<P/> 
+In the example we use homomorphisms between <C>A2c6</C> and <C>I2c6</C> 
+constructed in section <Ref Sect="algebra-homomorphism-lists"/>. 
 </Description> 
 </ManSection> 
 
 <Example>
 <![CDATA[
-gap> Ac6 := GroupRing( GF(2), Group( (1,2,3)(4,5) ) );;
-gap> Rc3 := GroupRing( GF(2), Group( (1,2,3) ) );;
-gap> homAR := AllHomsOfAlgebras( Ac6, Rc3 );;
-gap> mgiAR := List( homAR, h -> MappingGeneratorsImages(h) );;
-gap> Print( mgiAR, "\n" );
-[ [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ <zero> of ... ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*() ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], 
-      [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*(1,3,2) ] ] ]
-gap> homRA := AllHomsOfAlgebras( Rc3, Ac6 );;
-gap> mgiRA := List( homRA, h -> MappingGeneratorsImages(h) );;
-gap> Print( mgiRA, "\n" );
-[ [ [ (Z(2)^0)*(1,2,3) ], [ <zero> of ... ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*() ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ],
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,3,2) ] ] ]
-gap> C4 := PreCat1AlgebraByTailHeadEmbedding( homAR[6], homAR[6], homRA[8] );
-[AlgebraWithOne( GF(2), [ (Z(2)^0)*(1,2,3)(4,5) ] ) -> AlgebraWithOne( GF(2), 
-[ (Z(2)^0)*(1,2,3) ] )]
+gap> t4 := homAR[8]; 
+[ (Z(2)^0)*(1,6,5,4,3,2) ] -> [ (Z(2)^0)*(7,9,8) ]
+gap> e4 := homRA[8];
+[ (Z(2)^0)*(7,8,9) ] -> [ (Z(2)^0)*(1,5,3)(2,6,4) ]
+gap> C4 := PreCat1AlgebraByTailHeadEmbedding( t4, t4, e4 );
+[AlgebraWithOne( GF(2), [ (Z(2)^0)*(1,2,3,4,5,6) 
+ ] ) -> AlgebraWithOne( GF(2), [ (Z(2)^0)*(7,8,9) ] )]
 gap> IsCat1Algebra( C4 );
 true
 gap> Size( C4 );
@@ -151,23 +133,23 @@ gap> Display( C4 );
 
 Cat1-algebra [..=>..] :- 
 : source algebra has generators:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3)(4,5) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3,4,5,6) ]
 :  range algebra has generators:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(7,8,9) ]
 : tail homomorphism maps source generators to:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,3,2) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(7,8,9) ]
 : head homomorphism maps source generators to:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,3,2) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(7,8,9) ]
 : range embedding maps range generators to:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,3,2) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(1,5,3)(2,6,4) ]
 : kernel has generators:
-  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
+  [ (Z(2)^0)*()+(Z(2)^0)*(1,4)(2,5)(3,6), (Z(2)^0)*(1,2,3,4,5,6)+(Z(2)^0)*
+    (1,5,3)(2,6,4), (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,6,5,4,3,2) ]
 : boundary homomorphism maps generators of kernel to:
   [ <zero> of ..., <zero> of ..., <zero> of ... ]
 : kernel embedding maps generators of kernel to:
-  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
+  [ (Z(2)^0)*()+(Z(2)^0)*(1,4)(2,5)(3,6), (Z(2)^0)*(1,2,3,4,5,6)+(Z(2)^0)*
+    (1,5,3)(2,6,4), (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,6,5,4,3,2) ]
 ]]>
 </Example>
 

--- a/doc/convert.xml
+++ b/doc/convert.xml
@@ -21,20 +21,29 @@ The categories <M>\mathbf{Cat1Alg}</M> (cat<M>^{1}</M>-algebras)
 and <M>\mathbf{XModAlg}</M> (crossed modules) 
 are naturally equivalent <Cite Key="ellis1"/>.  
 This equivalence is outlined in what follows. 
-For a given crossed module <M>(\partial : A \rightarrow R)</M> 
-we can construct the semidirect product <M>R\ltimes A</M>
-thanks to the action of <M>R</M> on <M>A</M>. 
-If we define <M>t,h : R\ltimes A \rightarrow R</M> 
-and <M>e : R \rightarrow R \ltimes A</M> by 
+For a given crossed module <M>(\partial : S \rightarrow R)</M> 
+we can construct the semidirect product <M>R \ltimes S</M>
+thanks to the action of <M>R</M> on <M>S</M>. 
+If we define <M>t,h : R \ltimes S \rightarrow R</M> 
+and <M>e : R \rightarrow R \ltimes S</M> by 
 <Display>
-t(r,a) = r, \qquad 
-h(r,a) = r+\partial(a), \qquad 
+t(r,s) = r, \qquad 
+h(r,s) = r + \partial(s), \qquad 
 e(r) = (r,0), 
 </Display>
 respectively, then 
-<M>\mathcal{C} = (e;t,h : R \ltimes A \rightarrow R)</M> 
+<M>\mathcal{C} = (e;t,h : R \ltimes S \rightarrow R)</M> 
 is a cat<M>^{1}-</M>algebra.
 <P/> 
+Notice that <M>h</M> <E>is</E> an algebra homomorphism, since: 
+<Display>
+h(r_1r_2,~ r_1 \cdot s_2 + r_2 \cdot s_1 + s_1s_2) 
+~=~ 
+r_1r_2 + r_1(\partial s_2) + r_2(\partial s_1) + (\partial s_1)(\partial s_2) 
+~=~ 
+(r_1 + \partial s_1)(r_2 + \partial s_2). 
+</Display>
+<P/>
 Conversely, for a given cat<M>^{1}</M>-algebra 
 <M>\mathcal{C}=(e;t,h : A \rightarrow R)</M>, 
 the map <M>\partial : \ker t \rightarrow R</M> is a crossed module, 
@@ -43,7 +52,7 @@ where the action is multiplication action and
 <P/> 
 Since all of these operations are linked to the functions 
 <Ref Oper="Cat1Algebra"/> and <Ref Oper="XModAlgebra"/>, 
-they can be permormed by calling these two functions. 
+they can be performed by calling these two functions. 
 We may also use the function <Ref Oper="Cat1Algebra"/> 
 instead of the operation <Ref Oper="Cat1AlgebraSelect"/>.
 
@@ -54,38 +63,32 @@ instead of the operation <Ref Oper="Cat1AlgebraSelect"/>.
          Arg="X0" />
 <Description> 
 These operations are used for constructing a cat<M>^{1}</M>-algebra 
-from a given crossed module of algebras.
+from a given crossed module of algebras. 
+As an example we use the crossed module <C>XAB</C> constructed in 
+<Ref Oper="XModAlgebraByIdeal"/> 
+(The output from <C>Display</C> needs to be improved.) 
 </Description>
 </ManSection> 
 
 <Example>
 <![CDATA[
-gap> CXM := Cat1AlgebraOfXModAlgebra( XM );
-[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
-gap> Display( CXM );
+gap> CAB := Cat1AlgebraOfXModAlgebra( XAB );
+[Algebra( GF(5), [ v.1, v.2, v.3, v.4, v.5 ] ) -> A(l,m)]
+gap> Display( CAB );
 
-Cat1-algebra [..=>GF(2^2)[k4]] :- 
+Cat1-algebra [..=>A(l,m)] :- 
 :  range algebra has generators:
-  [ (Z(2)^0)*<identity> of ..., (Z(2)^0)*f1, (Z(2)^0)*f2 ]
+  
+[ 
+  [ [ Z(5)^0, 0*Z(5), 0*Z(5) ], [ 0*Z(5), Z(5)^0, 0*Z(5) ], 
+      [ 0*Z(5), 0*Z(5), Z(5)^0 ] ], 
+  [ [ 0*Z(5), Z(5)^0, Z(5)^3 ], [ 0*Z(5), 0*Z(5), Z(5)^0 ], 
+      [ 0*Z(5), 0*Z(5), 0*Z(5) ] ] ]
 : tail homomorphism maps source generators to:
 : range embedding maps range generators to:
-  [ [ (Z(2)^0)*<identity> of ..., <zero> of ... ], 
-  [ (Z(2)^0)*f1, <zero> of ... ], [ (Z(2)^0)*f2, <zero> of ... ] ]
+  [ v.1, v.2 ]
 : kernel has generators:
-  [ [ <zero> of ..., <zero> of ... ], 
-  [ <zero> of ..., (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^
-        0)*f1*f2 ], 
-  [ <zero> of ..., (Z(2^2))*<identity> of ...+(Z(2^2))*f1+(Z(2^2))*f2+(
-        Z(2^2))*f1*f2 ], 
-  [ <zero> of ..., (Z(2^2)^2)*<identity> of ...+(Z(2^2)^2)*f1+(Z(2^2)^2)*f2+(
-        Z(2^2)^2)*f1*f2 ] ]
-gap> 
-gap> SCXM := Source( CXM );;
-gap> Length( SCXM );
-1024
-gap> KnownAttributesOfObject( SCXM );
-[ "LENGTH" ]
-gap> ## not very satisfactory - the source should be an algebra! 
+  Algebra( GF(5), [ v.4, v.5 ] )
 ]]>
 </Example>
 

--- a/doc/xmod.xml
+++ b/doc/xmod.xml
@@ -65,20 +65,23 @@ it is the case that <M>{\partial(S)}</M> is an ideal of <M>R</M>.
 
 <Example>
 <![CDATA[
-gap> m := [ [ 0, 1, 2, 3 ], [ 0, 0, 4, 5 ], [0, 0, 0, 6 ], [ 0, 0, 0, 0 ] ];; 
-gap> A := Algebra( Rationals, [ m ] );
-<algebra over Rationals, with 1 generators>
-gap> m^2; m^3;
-[ [ 0, 0, 4, 17 ], [ 0, 0, 0, 24 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]
-[ [ 0, 0, 0, 24 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]
-gap> B := Subalgebra( A, [ m^2, m^3 ] );;  
-gap> X1 := XModAlgebraByIdeal( A, B ); 
-[ <algebra of dimension 2 over Rationals> -> <algebra of dimension 
-3 over Rationals> ]
-gap> act1 := XModAlgebraAction( X1 );; 
-gap> aut1 := ImageElm( act1, m );; 
-gap> ImageElm( aut1, m^2 );
-[ [ 0, 0, 0, 24 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]
+gap> F := GF(5);;
+gap> one := One(F);;
+gap> two := Z(5);; 
+gap> z := Zero( F );; 
+gap> l := [ [one,z,z], [z,one,z], [z,z,one] ];; 
+gap> m := [ [z,one,two^3], [z,z,one], [z,z,z] ];;
+gap> n := [ [z,z,one], [z,z,z], [z,z,z] ];; 
+gap> A := Algebra( F, [l,m] );; 
+gap> SetName( A, "A(l,m)" ); 
+gap> B := Subalgebra( A, [m] );; 
+gap> SetName( B, "A(m)" ); 
+gap> IsIdeal( A, B ); 
+true
+gap> act := AlgebraActionByMultiplication( A, B );; 
+gap> XAB := XModAlgebraByIdeal( A, B ); 
+[ A(m) -> A(l,m) ]
+gap> SetName( XAB, "XAB" ); 
 ]]>
 </Example>
 

--- a/lib/alg2obj.gd
+++ b/lib/alg2obj.gd
@@ -17,9 +17,6 @@ DeclareProperty( "Is2dAlgebraObject", Is2DimensionalDomain );
 
 DeclareOperation( "Sub2dAlgebra", [ Is2dAlgebra, IsAlgebra, IsAlgebra ] );
 
-DeclareOperation( "AllHomsOfAlgebras", [ IsAlgebra, IsAlgebra ] );
-DeclareOperation( "AllBijectiveHomsOfAlgebras", [ IsAlgebra, IsAlgebra ] );
-DeclareOperation( "AllIdempotentHomsOfAlgebras", [ IsAlgebra, IsAlgebra ] );
 
 #########################  (pre-)crossed modules  ###################### 
 
@@ -72,17 +69,11 @@ DeclareOperation( "PreCat1AlgebraObj",
     [ IsAlgebraHomomorphism, IsAlgebraHomomorphism, IsAlgebraHomomorphism ] );
 DeclareOperation( "PreCat1AlgebraByTailHeadEmbedding",
     [ IsAlgebraHomomorphism, IsAlgebraHomomorphism, IsAlgebraHomomorphism ] );
-DeclareAttribute( "Equivalence", IsPreCat1Algebra );
 DeclareAttribute( "HeadMap", IsPreCat1Algebra );
 DeclareAttribute( "TailMap", IsPreCat1Algebra );
 DeclareAttribute( "RangeEmbedding", IsPreCat1Algebra );
 DeclareAttribute( "KernelEmbedding", IsPreCat1Algebra );
 
-DeclareAttribute( "Equivalence", IsPreCat1Algebra );
-DeclareAttribute( "SourceForEquivalence", IsCat1Algebra );
-DeclareAttribute( "BoundaryForEquivalence", IsCat1Algebra );
-DeclareFilter( "IsEquivalenceHead", IsCat1Algebra );
-DeclareFilter( "IsEquivalenceTail", IsCat1Algebra );
 DeclareFilter( "IsXModAlgebraConst", IsCat1Algebra );
 DeclareAttribute( "XModAlgebraConst", IsCat1Algebra );
 
@@ -110,6 +101,4 @@ DeclareAttribute( "PreXModAlgebraOfPreCat1Algebra", IsPreCat1Algebra );
 DeclareAttribute( "PreCat1AlgebraOfPreXModAlgebra", IsPreXModAlgebra );
 DeclareAttribute( "XModAlgebraOfCat1Algebra", IsCat1Algebra );
 DeclareAttribute( "Cat1AlgebraOfXModAlgebra", IsXModAlgebra );
-DeclareOperation( "EquivalenceTail", [ IsEquivalenceTail ] );
-DeclareOperation( "EquivalenceHead", [ IsEquivalenceHead ] );
 DeclareOperation( "SDproduct", [ Is2dAlgebraObject ] );

--- a/lib/alg2obj.gi
+++ b/lib/alg2obj.gi
@@ -59,245 +59,6 @@ function( obj, src, rng )
     fi;
 end );
 
-##############################################################################
-##
-#M  AllHomsOfAlgebras
-##
-InstallMethod( AllHomsOfAlgebras, "generic method for algebras",
-    true, [ IsAlgebra, IsAlgebra ], 0,
-function( G, H )
-
-    local A,B,a,b,h,f,i,sonuc,mler,j,k,eH,l,L,g,H_G,genG;
-
-    eH := Elements(H);
-    if ( "IsGroupAlgebra" in KnownPropertiesOfObject(G) ) then
-        H_G := UnderlyingGroup(G);
-        L := MinimalGeneratingSet(H_G);
-        genG := List( L , g -> g^Embedding(H_G,G) );
-    else
-        genG := GeneratorsOfAlgebra(G);
-    fi;
-    if (Length(genG) = 0) then
-        genG := GeneratorsOfAlgebra(G);
-    fi;
-    mler := [];
-    if Length(genG) = 1 then
-        for i in [1..Size(H)] do
-            f := AlgebraHomomorphismByImages(G,H,genG,[eH[i]]);
-            if ((f <> fail) and  (not f in mler))  then 
-                Add(mler,f);
-            else 
-                continue; 
-            fi;            
-        od;
-    elif Length(genG) = 2 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                f := AlgebraHomomorphismByImages(G,H,genG,[eH[i],eH[j]]);
-                if ((f <> fail) and  (not f in mler))  then 
-                    Add(mler,f);
-                else 
-                    continue; 
-                fi; 
-            od;
-        od;
-    elif Length(genG) = 3 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                for k in [1..Size(H)] do
-                    f := AlgebraHomomorphismByImages( G, H, genG,
-                             [eH[i],eH[j],eH[k]]);
-                    if ((f <> fail) and  (not f in mler))  then 
-                        Add(mler,f);
-                    else 
-                        continue; 
-                    fi; 
-                od;
-            od;
-        od;
-    elif Length(genG) = 4 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                for k in [1..Size(H)] do
-                    for l in [1..Size(H)] do
-                        f := AlgebraHomomorphismByImages( G, H, genG, 
-                                 [eH[i],eH[j],eH[k],eH[l]]);
-                        if ((f <> fail) and  (not f in mler))  then 
-                            Add(mler,f);
-                        else 
-                            continue; 
-                       fi;    
-                    od;
-                od;
-            od;
-        od;
-    else
-        Print("not implemented yet");    
-    fi;
-    #Print(Length(mler));
-    #Print("\n");
-    return mler;
-end );
-
-##############################################################################
-##
-#M  AllBijectiveHomsOfAlgebras
-##
-InstallMethod( AllBijectiveHomsOfAlgebras, "generic method for algebras",
-    true, [ IsAlgebra, IsAlgebra ], 0,
-function( G, H )
-
-    local A,B,a,b,h,f,i,sonuc,mler,j,k,eH,l,L,g,H_G,genG;
-
-    eH := Elements(H);
-    if ( "IsGroupAlgebra" in KnownPropertiesOfObject(G) ) then
-        H_G := UnderlyingGroup(G);
-        L := MinimalGeneratingSet(H_G);
-        genG := List( L , g -> g^Embedding(H_G,G) );
-    else
-        genG := GeneratorsOfAlgebra(G);
-    fi;
-    if  (Length(genG) = 0) then
-        genG := GeneratorsOfAlgebra(G);
-    fi;
-    mler := [];
-    if Length(genG) = 1 then 
-        for i in [1..Size(H)] do
-            f := AlgebraHomomorphismByImages(G,H,genG,[eH[i]]);
-            if ((f <> fail) and  (not f in mler) and (IsBijective(f)))  then 
-                Add(mler,f);
-            else 
-                continue; 
-            fi;            
-        od;
-    elif Length(genG) = 2 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                f := AlgebraHomomorphismByImages(G,H,genG,[eH[i],eH[j]]);
-                if ((f <> fail) and (not f in mler) and (IsBijective(f))) then 
-                    Add(mler,f);
-                else 
-                    continue; 
-                fi;        
-            od;
-        od;
-    elif Length(genG) = 3 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                for k in [1..Size(H)] do
-                    f := AlgebraHomomorphismByImages( G, H, genG, 
-                             [eH[i],eH[j],eH[k]]);
-                    if ((f <> fail) and (not f in mler) 
-                                    and (IsBijective(f))) then 
-                        Add(mler,f);
-                    else 
-                        continue; 
-                    fi;    
-                od;
-            od;
-        od;
-    elif Length(genG) = 4 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                for k in [1..Size(H)] do
-                    for l in [1..Size(H)] do
-                        f := AlgebraHomomorphismByImages( G, H, genG, 
-                                 [eH[i],eH[j],eH[k],eH[l]]);
-                        if ((f <> fail) and (not f in mler) 
-                                        and (IsBijective(f))) then 
-                            Add(mler,f);
-                        else 
-                            continue; 
-                        fi;    
-                    od;
-                od;
-            od;
-        od;
-    else
-        Print("not implemented yet");    
-    fi;
-    #Print(Length(mler));
-    #Print("\n");
-    return mler;
-end );
-
-##############################################################################
-##
-#M  AllIdempotentHomsOfAlgebras
-##
-InstallMethod( AllIdempotentHomsOfAlgebras, "generic method for algebras",
-    true, [ IsAlgebra, IsAlgebra ], 0,
-function( G, H )
-
-local A,B,a,b,h,f,i,sonuc,mler,j,k,eH,l,L,g,H_G,genG;
-
-    eH := Elements(H);
-    H_G := UnderlyingGroup(G);
-    L := MinimalGeneratingSet(H_G);
-    genG := List( L , g -> g^Embedding(H_G,G) );
-    if ( Length(genG) = 0 ) then
-            genG := GeneratorsOfAlgebra(G);
-    fi;
-    mler := [];
-    if Length(genG) = 1 then
-        for i in [1..Size(H)] do
-            f := AlgebraHomomorphismByImages(G,H,genG,[eH[i]]);
-            if ((f <> fail) and  (not f in mler) and (f*f=f))  then 
-                Add(mler,f);
-            else 
-                continue; 
-            fi; 
-        od;
-    elif Length(genG) = 2 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                f := AlgebraHomomorphismByImages(G,H,genG,[eH[i],eH[j]]);
-                if ((f <> fail) and  (not f in mler) and (f*f=f))  then 
-                    Add(mler,f);
-                else 
-                    continue; 
-                fi;        
-            od;
-        od;
-    elif Length(genG) = 3 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                for k in [1..Size(H)] do
-                    f := AlgebraHomomorphismByImages( G, H, genG, 
-                             [eH[i],eH[j],eH[k]]);
-                    if ((f <> fail) and  (not f in mler) and (f*f=f)) then 
-                        Add(mler,f);
-                    else 
-                        continue; 
-                    fi;    
-                od;
-            od;
-        od;
-    elif Length(genG) = 4 then
-        for i in [1..Size(H)] do
-            for j in [1..Size(H)] do
-                for k in [1..Size(H)] do
-                    for l in [1..Size(H)] do
-                        f := AlgebraHomomorphismByImages( G, H, genG, 
-                                 [eH[i],eH[j],eH[k],eH[l]]);
-                        if ((f <> fail) and  (not f in mler) and (f*f=f)) then 
-                            Add(mler,f);
-                        else 
-                            continue; 
-                        fi;    
-                    od;
-                od;
-            od;
-        od;
-    else
-        Print("not implemented yet");    
-    fi;
-    #Print(Length(mler));
-    #Print("\n");
-    return mler;
-end );
-
-
 
 #########################  (pre-)crossed modules  ########################### 
 
@@ -1078,9 +839,6 @@ function( C1A )
     t := TailMap( C1A );
     e := RangeEmbedding( C1A );
     # checking the first condition of cat-1 group
-    if Equivalence(t) then    
-        return true;
-    fi;
     idrng := IdentityMapping( Crng );
     he := CompositionMapping( h, e );
     te := CompositionMapping( t, e );
@@ -1257,7 +1015,7 @@ InstallMethod( PreCat1AlgebraObj, "for tail, head, embedding", true,
     if not ok then
         return fail;
     fi;
-    ok := IsCat1Algebra( C1A );
+##    ok := IsCat1Algebra( C1A );
     return C1A;
 end );
 
@@ -1474,9 +1232,6 @@ function( C1A )
     h := HeadMap( C1A );
     t := TailMap( C1A );
     e := RangeEmbedding( C1A );
-    if Equivalence(t) then    
-        return true;
-    fi;
     kerC := Kernel( C1A );
     f := KernelEmbedding( C1A );
     kert := Kernel( t );
@@ -1736,7 +1491,6 @@ function( gf, size, gpnum, num )
     # e := InclusionMappingAlgebra(A,B);
     kert := Kernel( t );
     SetName( kert, L[2] );
-    SetEquivalence( t, false );
     return PreCat1AlgebraByEndomorphisms( t, h );
 end );
 
@@ -1777,7 +1531,6 @@ function( t, h, e )
     kergen := GeneratorsOfAlgebra( kert );
     imbdy := List( kergen, x -> Image( h, x) );
     bdy := AlgebraHomomorphismByImagesNC( kert, R, kergen, imbdy );
-    SetEquivalence( tres, false );
     PC := PreCat1AlgebraObj( tres, hres, eres );
     SetBoundary( PC, bdy );
     SetKernelEmbedding( PC, f );
@@ -1793,7 +1546,7 @@ InstallMethod( PreCat1AlgebraByEndomorphisms,
     [ IsAlgebraHomomorphism, IsAlgebraHomomorphism ], 0,
 function( et, eh )
 
-    local  G, gG, R, t, h, e;
+    local  G, gG, R, t, h, e, A, ok;
 
     if not ( IsEndoMapping( et ) and IsEndoMapping( eh ) ) then
         Info( InfoXModAlg, 1, "et, eh must both be group endomorphisms" );
@@ -1812,8 +1565,14 @@ function( et, eh )
     gG := GeneratorsOfAlgebra( G );
     t := AlgebraHomomorphismByImages( G, R, gG, List( gG, g->Image( et, g ) ) );
     h := AlgebraHomomorphismByImages( G, R, gG, List( gG, g->Image( eh, g ) ) );
-    e := InclusionMappingAlgebra( G, R );
-    return PreCat1AlgebraByTailHeadEmbedding( t, h, e );
+    e := InclusionMappingAlgebra( G, R ); 
+    A := PreCat1AlgebraByTailHeadEmbedding( t, h, e ); 
+    if ( A = fail ) then 
+        return fail; 
+    fi; 
+    SetIsPreCat1Algebra( A, true ); 
+    ok := IsCat1Algebra( A ); 
+    return A; 
 end );
 
 #############################################################################
@@ -1858,18 +1617,6 @@ InstallMethod( KernelEmbedding, "method for a pre-cat1-algebra", true,
 
 ##############################################################################
 ##
-#M  Kernel( t,h ) . . . . . . . . . . . . . . . . . . . for a pre-cat1-algebra
-##
-InstallOtherMethod( Kernel, "method for a pre-cat1-algebra",
-    [ IsEquivalenceHead and IsAlgebraHomomorphism ],
-    EquivalenceHead );
-
-InstallOtherMethod( Kernel, "method for a pre-cat1-algebra",
-    [ IsEquivalenceTail and IsAlgebraHomomorphism ],
-    EquivalenceTail );
-
-##############################################################################
-##
 #M  AllCat1Algebras
 ##
 InstallMethod( AllCat1Algebras, "generic method for cat1-algebras",
@@ -1880,7 +1627,7 @@ function( F, G )
 
     A := GroupRing( F, G );
     PreCat1_ler := [];
-    Iler := AllIdempotentHomsOfAlgebras( A, A );
+    Iler := AllIdempotentAlgebraHomomorphisms( A, A );
     PreCat1_ler := [];
     for i in [1..Length(Iler)] do
         for j in [1..Length(Iler)] do
@@ -1925,13 +1672,13 @@ function( C1A1, C1A2 )
         if ( "AllAutosOfAlgebras" in KnownAttributesOfObject(T1) ) then
             alpha1 := AllAutosOfAlgebras(T1);
         else
-            alpha1 := AllBijectiveHomsOfAlgebras(T1,T1);
+            alpha1 := AllBijectiveAlgebraHomomorphisms(T1,T1);
             SetAllAutosOfAlgebras(T1,alpha1);
         fi;
     else
-        alpha1 := AllBijectiveHomsOfAlgebras(T1,T2);
+        alpha1 := AllBijectiveAlgebraHomomorphisms(T1,T2);
     fi;
-    phi1 := AllBijectiveHomsOfAlgebras(G1,G2);
+    phi1 := AllBijectiveAlgebraHomomorphisms(G1,G2);
     m1_ler := [];        
     for alp in alpha1 do
         for ph in phi1 do
@@ -2006,51 +1753,6 @@ end );
 
 ##########################  conversion functions  ##########################  
 
-############################################################################
-##
-#M  EquivalenceTail. . . . convert a pre-crossed module to a pre-cat1-algebra
-##
-InstallMethod( EquivalenceTail,
-    "convert a pre-crossed module to a pre-cat1-algebra", true, 
-    [  IsEquivalenceTail ], 0,
-function( f )
-
-    local  A, R, RA,zR,Ker ;
-
-    RA := Source( f );
-    R := Range( f );
-    A := SourceForEquivalence(f);
-    zR := Zero( R );
-    Ker := Cartesian([zR],A);      
-    return Ker;
-end ); 
-
-#############################################################################
-##
-#M  EquivalenceHead. . . . convert a pre-crossed module to a pre-cat1-algebra
-##
-InstallMethod( EquivalenceHead,
-    "convert a pre-crossed module to a pre-cat1-algebra", true,
-    [ IsEquivalenceHead ], 0,
-function( f )
-
-    local  A, R, RA, eA, uzA, Xbdy, list, i, a, x, Ker ;
-
-    RA := Source( f );
-    R := Range( f );
-    A := SourceForEquivalence(f);
-    eA := Elements(A);;
-    uzA := Size(A);
-    Xbdy := BoundaryForEquivalence(f);    
-    list := [];;
-    for i in [1..uzA] do
-        a := eA[i];
-        x := [-(Image(Xbdy,a)),a];
-        Add( list, x );
-    od;
-    return list;
-end ); 
-
 #############################################################################
 ##
 #M  PreXModAlgebraOfPreCat1Algebra
@@ -2112,57 +1814,35 @@ InstallMethod( PreCat1AlgebraOfPreXModAlgebra,
     [ IsPreXModAlgebra ], 0,
 function( XM )
 
-    local  A, gA, Xact, Xbdy, R, gR, zA, RA, x, t, h, e;
+    local  S, R, act, bdy, P, info, vecP, dimP, dimR, vecR, zR, dimS, vecS, zS, 
+           j, imgs, t, h, e, C;
 
-    A := Source( XM );
-    gA := GeneratorsOfAlgebra( A );
+    S := Source( XM );
     R := Range( XM );
-    #gR := GeneratorsOfAlgebra( R );
-    zA := Zero( A );
-    Xact := XModAlgebraAction( XM );
-    Xbdy := Boundary( XM );  
-    RA := Cartesian(R,A);
-    #? should DirectSumOfAlgebras be used here? 
-    #? but no Embedding available for  R -> RA  or  A -> RA 
-    t := rec( fun:= x->x[1]);
-    ObjectifyWithAttributes( t, 
-        NewType( GeneralMappingsFamily( ElementsFamily( FamilyObj(RA) ),
-            ElementsFamily( FamilyObj(R) ) ),
-        IsSPMappingByFunctionRep and IsSingleValued
-            and IsTotal and IsGroupHomomorphism ),
-        Source, RA,
-        SourceForEquivalence, A,
-        Range, R,
-        Equivalence, true,
-        IsAlgebraHomomorphism, true,
-        IsEquivalenceTail, true,
-        IsEquivalenceHead, false,
-        IsXModAlgebraConst, true,
-        XModAlgebraConst, XM );
-    h := rec( fun:= x->x[1]+Image(Xbdy,x[2]));
-    ObjectifyWithAttributes( h, 
-        NewType(GeneralMappingsFamily( ElementsFamily( FamilyObj(RA) ),
-            ElementsFamily( FamilyObj(R) ) ),
-        IsSPMappingByFunctionRep and IsSingleValued
-            and IsTotal and IsGroupHomomorphism ),
-        Source, RA,
-        SourceForEquivalence, A,
-        Range, R,
-        IsAlgebraHomomorphism, true,
-        BoundaryForEquivalence, Xbdy,
-        XModAlgebraAction, Xact,
-        IsEquivalenceHead, true,
-        IsEquivalenceTail, false );
-    e := rec( fun:= x->[x,zA]);
-    ObjectifyWithAttributes( e, 
-        NewType(GeneralMappingsFamily( ElementsFamily( FamilyObj(R) ),
-            ElementsFamily( FamilyObj(RA) ) ),
-        IsSPMappingByFunctionRep and IsSingleValued
-            and IsTotal and IsGroupHomomorphism ),
-        Source, R,
-        Range, RA,
-        IsAlgebraHomomorphism, true );
-    return PreCat1AlgebraObj( t, h, e ); 
+    act := XModAlgebraAction( XM );
+    bdy := Boundary( XM ); 
+    P := SemidirectProductOfAlgebras( R, act, S ); 
+    info := SemidirectProductOfAlgebrasInfo( P );
+    vecP := BasisVectors( Basis( P ) ); 
+    dimP := Length( vecP ); 
+    dimR := Dimension( R ); 
+    zR := Zero( R ); 
+    dimS := Dimension( S ); 
+    zS := Zero( S ); 
+    vecR := BasisVectors( Basis( R ) ); 
+    vecS := BasisVectors( Basis( S ) ); 
+    imgs := ListWithIdenticalEntries( dimP, 0 ); 
+    for j in [1..dimR] do 
+        imgs[j] := vecR[j]; 
+    od; 
+    for j in [dimR+1..dimP] do 
+        imgs[j] := Image( bdy, vecS[j-dimR] ); 
+    od; 
+    h := AlgebraHomomorphismByImages( P, R, vecP, imgs ); 
+    t := Projection( P, 1 ); 
+    e := Embedding( P, 1 );
+    C := PreCat1AlgebraObj( t, h, e ); 
+    return C; 
 end ); 
 
 ##############################################################################

--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -28,6 +28,13 @@ DeclareOperation( "MultiplierHomomorphism",
 DeclareOperation( "ModuleHomomorphism",
     [ IsAlgebra, IsRing ] ); 
 
+DeclareOperation( "AllAlgebraHomomorphisms", 
+    [ IsAlgebra, IsAlgebra ] );
+DeclareOperation( "AllBijectiveAlgebraHomomorphisms", 
+    [ IsAlgebra, IsAlgebra ] );
+DeclareOperation( "AllIdempotentAlgebraHomomorphisms", 
+    [ IsAlgebra, IsAlgebra ] );
+
 ##############################  algebra actions  #################### 
 
 DeclareGlobalFunction( "ElementsLeftActing" );

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -44,6 +44,243 @@ function ( R )
     return MR;
 end );
 
+##############################################################################
+##
+#M  AllAlgebraHomomorphisms
+##
+InstallMethod( AllAlgebraHomomorphisms, "generic method for algebras",
+    true, [ IsAlgebra, IsAlgebra ], 0,
+function( G, H )
+
+    local A,B,a,b,h,f,i,sonuc,mler,j,k,eH,l,L,g,H_G,genG;
+
+    eH := Elements(H);
+    if ( "IsGroupAlgebra" in KnownPropertiesOfObject(G) ) then
+        H_G := UnderlyingGroup(G);
+        L := MinimalGeneratingSet(H_G);
+        genG := List( L , g -> g^Embedding(H_G,G) );
+    else
+        genG := GeneratorsOfAlgebra(G);
+    fi;
+    if (Length(genG) = 0) then
+        genG := GeneratorsOfAlgebra(G);
+    fi;
+    mler := [];
+    if Length(genG) = 1 then
+        for i in [1..Size(H)] do
+            f := AlgebraHomomorphismByImages(G,H,genG,[eH[i]]);
+            if ((f <> fail) and  (not f in mler))  then 
+                Add(mler,f);
+            else 
+                continue; 
+            fi;            
+        od;
+    elif Length(genG) = 2 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                f := AlgebraHomomorphismByImages(G,H,genG,[eH[i],eH[j]]);
+                if ((f <> fail) and  (not f in mler))  then 
+                    Add(mler,f);
+                else 
+                    continue; 
+                fi; 
+            od;
+        od;
+    elif Length(genG) = 3 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                for k in [1..Size(H)] do
+                    f := AlgebraHomomorphismByImages( G, H, genG,
+                             [eH[i],eH[j],eH[k]]);
+                    if ((f <> fail) and  (not f in mler))  then 
+                        Add(mler,f);
+                    else 
+                        continue; 
+                    fi; 
+                od;
+            od;
+        od;
+    elif Length(genG) = 4 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                for k in [1..Size(H)] do
+                    for l in [1..Size(H)] do
+                        f := AlgebraHomomorphismByImages( G, H, genG, 
+                                 [eH[i],eH[j],eH[k],eH[l]]);
+                        if ((f <> fail) and  (not f in mler))  then 
+                            Add(mler,f);
+                        else 
+                            continue; 
+                       fi;    
+                    od;
+                od;
+            od;
+        od;
+    else
+        Print("not implemented yet");    
+    fi;
+    #Print(Length(mler));
+    #Print("\n");
+    return mler;
+end );
+
+##############################################################################
+##
+#M  AllBijectiveAlgebraHomomorphisms
+##
+InstallMethod( AllBijectiveAlgebraHomomorphisms, "generic method for algebras",
+    true, [ IsAlgebra, IsAlgebra ], 0,
+function( G, H )
+
+    local A,B,a,b,h,f,i,sonuc,mler,j,k,eH,l,L,g,H_G,genG;
+
+    eH := Elements(H);
+    if ( "IsGroupAlgebra" in KnownPropertiesOfObject(G) ) then
+        H_G := UnderlyingGroup(G);
+        L := MinimalGeneratingSet(H_G);
+        genG := List( L , g -> g^Embedding(H_G,G) );
+    else
+        genG := GeneratorsOfAlgebra(G);
+    fi;
+    if  (Length(genG) = 0) then
+        genG := GeneratorsOfAlgebra(G);
+    fi;
+    mler := [];
+    if Length(genG) = 1 then 
+        for i in [1..Size(H)] do
+            f := AlgebraHomomorphismByImages(G,H,genG,[eH[i]]);
+            if ((f <> fail) and  (not f in mler) and (IsBijective(f)))  then 
+                Add(mler,f);
+            else 
+                continue; 
+            fi;            
+        od;
+    elif Length(genG) = 2 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                f := AlgebraHomomorphismByImages(G,H,genG,[eH[i],eH[j]]);
+                if ((f <> fail) and (not f in mler) and (IsBijective(f))) then 
+                    Add(mler,f);
+                else 
+                    continue; 
+                fi;        
+            od;
+        od;
+    elif Length(genG) = 3 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                for k in [1..Size(H)] do
+                    f := AlgebraHomomorphismByImages( G, H, genG, 
+                             [eH[i],eH[j],eH[k]]);
+                    if ((f <> fail) and (not f in mler) 
+                                    and (IsBijective(f))) then 
+                        Add(mler,f);
+                    else 
+                        continue; 
+                    fi;    
+                od;
+            od;
+        od;
+    elif Length(genG) = 4 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                for k in [1..Size(H)] do
+                    for l in [1..Size(H)] do
+                        f := AlgebraHomomorphismByImages( G, H, genG, 
+                                 [eH[i],eH[j],eH[k],eH[l]]);
+                        if ((f <> fail) and (not f in mler) 
+                                        and (IsBijective(f))) then 
+                            Add(mler,f);
+                        else 
+                            continue; 
+                        fi;    
+                    od;
+                od;
+            od;
+        od;
+    else
+        Print("not implemented yet");    
+    fi;
+    #Print(Length(mler));
+    #Print("\n");
+    return mler;
+end );
+
+##############################################################################
+##
+#M  AllIdempotentAlgebraHomomorphisms
+##
+InstallMethod( AllIdempotentAlgebraHomomorphisms, "generic method for algebras",
+    true, [ IsAlgebra, IsAlgebra ], 0,
+function( G, H )
+
+local A,B,a,b,h,f,i,sonuc,mler,j,k,eH,l,L,g,H_G,genG;
+
+    eH := Elements(H);
+    H_G := UnderlyingGroup(G);
+    L := MinimalGeneratingSet(H_G);
+    genG := List( L , g -> g^Embedding(H_G,G) );
+    if ( Length(genG) = 0 ) then
+            genG := GeneratorsOfAlgebra(G);
+    fi;
+    mler := [];
+    if Length(genG) = 1 then
+        for i in [1..Size(H)] do
+            f := AlgebraHomomorphismByImages(G,H,genG,[eH[i]]);
+            if ((f <> fail) and  (not f in mler) and (f*f=f))  then 
+                Add(mler,f);
+            else 
+                continue; 
+            fi; 
+        od;
+    elif Length(genG) = 2 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                f := AlgebraHomomorphismByImages(G,H,genG,[eH[i],eH[j]]);
+                if ((f <> fail) and  (not f in mler) and (f*f=f))  then 
+                    Add(mler,f);
+                else 
+                    continue; 
+                fi;        
+            od;
+        od;
+    elif Length(genG) = 3 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                for k in [1..Size(H)] do
+                    f := AlgebraHomomorphismByImages( G, H, genG, 
+                             [eH[i],eH[j],eH[k]]);
+                    if ((f <> fail) and  (not f in mler) and (f*f=f)) then 
+                        Add(mler,f);
+                    else 
+                        continue; 
+                    fi;    
+                od;
+            od;
+        od;
+    elif Length(genG) = 4 then
+        for i in [1..Size(H)] do
+            for j in [1..Size(H)] do
+                for k in [1..Size(H)] do
+                    for l in [1..Size(H)] do
+                        f := AlgebraHomomorphismByImages( G, H, genG, 
+                                 [eH[i],eH[j],eH[k],eH[l]]);
+                        if ((f <> fail) and  (not f in mler) and (f*f=f)) then 
+                            Add(mler,f);
+                        else 
+                            continue; 
+                        fi;    
+                    od;
+                od;
+            od;
+        od;
+    else
+        Print("not implemented yet");    
+    fi;
+    #Print(Length(mler));
+    #Print("\n");
+    return mler;
+end );
 
 
 #############################  algebra mappings  ############################ 
@@ -406,11 +643,6 @@ end );
 #############################################################################
 ##
 #M  SemidirectProductOfAlgebras( <A1>, <act>, <A2> )
-##
-##  Construct a s.c. algebra.
-##  (There are special methods for appropriate matrix algebras.)
-##
-#T  embeddings/projections should be provided!
 ##
 InstallMethod( SemidirectProductOfAlgebras,
     "for two algebras and an action",

--- a/tst/algebra.tst
+++ b/tst/algebra.tst
@@ -10,17 +10,17 @@ gap> SetInfoLevel( InfoXModAlg, 0 );
 gap> SetInfoLevel( InfoXModAlg, saved_infolevel_xmodalg );; 
 gap> STOP_TEST( "algebra.tst", 10000 );
 
-gap> Ac6 := GroupRing( GF(5), Group( (1,2,3,4,5,6) ) );;
-gap> vecA := BasisVectors( Basis( Ac6 ) );; 
+gap> A5c6 := GroupRing( GF(5), Group( (1,2,3,4,5,6) ) );;
+gap> vecA := BasisVectors( Basis( A5c6 ) );; 
 gap> v := vecA[1] + vecA[3] + vecA[5];
 (Z(5)^0)*()+(Z(5)^0)*(1,3,5)(2,4,6)+(Z(5)^0)*(1,5,3)(2,6,4)
-gap> Ic6 := Ideal( Ac6, [v] );; 
-gap> act := AlgebraActionByMultiplication( Ac6, Ic6 );; 
+gap> I5c6 := Ideal( A5c6, [v] );; 
+gap> act := AlgebraActionByMultiplication( A5c6, I5c6 );; 
 gap> act2 := Image( act, vecA[2] );; 
 gap> Image( act2, v );
 (Z(5)^0)*(1,2,3,4,5,6)+(Z(5)^0)*(1,4)(2,5)(3,6)+(Z(5)^0)*(1,6,5,4,3,2)
 
-gap> P := SemidirectProductOfAlgebras( Ac6, act, Ic6 ); 
+gap> P := SemidirectProductOfAlgebras( A5c6, act, I5c6 ); 
 <algebra of dimension 8 over GF(5)>
 gap> Embedding( P, 1 );
 [ (Z(5)^0)*(), (Z(5)^0)*(1,2,3,4,5,6), (Z(5)^0)*(1,3,5)(2,4,6), 
@@ -36,6 +36,48 @@ gap> Projection( P, 1 );
   (Z(5)^0)*(1,4)(2,5)(3,6), (Z(5)^0)*(1,5,3)(2,6,4), (Z(5)^0)*(1,6,5,4,3,2), 
   <zero> of ..., <zero> of ... ]
 
+
+gap> A2c6 := GroupRing( GF(2), Group( (1,2,3,4,5,6) ) );;
+gap> R2c3 := GroupRing( GF(2), Group( (7,8,9) ) );;
+gap> homAR := AllAlgebraHomomorphisms( A2c6, R2c3 );;
+gap> List( homAR, h -> MappingGeneratorsImages(h) );
+[ [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ <zero> of ... ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*() ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*()+(Z(2)^0)*(7,8,9) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(7,8,9)+(Z(2)^0)*(7,9,8) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*()+(Z(2)^0)*(7,9,8) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(7,8,9) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(7,8,9)+(Z(2)^0)*(7,9,8) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(7,9,8) ] ] ]
+gap> homRA := AllAlgebraHomomorphisms( R2c3, A2c6 );;
+gap> List( homRA, h -> MappingGeneratorsImages(h) );
+[ [ [ (Z(2)^0)*(7,8,9) ], [ <zero> of ... ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*() ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,3,5)(2,4,6) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)(2,6,4) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,5,3)(2,6,4) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*(1,3,5)(2,4,6) ] ], 
+  [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)(2,6,4) ] 
+     ], [ [ (Z(2)^0)*(7,8,9) ], [ (Z(2)^0)*(1,5,3)(2,6,4) ] ] ]
+gap> bijAA := AllBijectiveAlgebraHomomorphisms( A2c6, A2c6 );;
+gap> List( bijAA, h -> MappingGeneratorsImages(h) );
+[ [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,4)(2,5)(3,6) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*()+(Z(2)^0)*(1,4)(2,5)(3,6)+(Z(2)^0)*(1,5,3)(2,6,4) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(1,2,3,4,5,6) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*(1,2,3,4,5,6)+(Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)
+            (2,6,4) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], 
+      [ (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,5,3)(2,6,4)+(Z(2)^0)*
+            (1,6,5,4,3,2) ] ], 
+  [ [ (Z(2)^0)*(1,6,5,4,3,2) ], [ (Z(2)^0)*(1,6,5,4,3,2) ] ] ]
+gap> ideAA := AllIdempotentAlgebraHomomorphisms( A2c6, A2c6 );; 
+gap> Length( ideAA );
+14
 
 
 ############################################################################

--- a/tst/cat1.tst
+++ b/tst/cat1.tst
@@ -27,36 +27,16 @@ gap> IsAlgebraAction( act );;
 gap> IsAlgebraHomomorphism( bdy );; 
 gap> XM := PreXModAlgebraByBoundaryAndAction( bdy, act );;
 gap> IsXModAlgebra( XM );;
+
 gap> ############################ 
-gap> ## Chapter 2,  Section 2.1.2
-gap> Ac6 := GroupRing( GF(2), Group( (1,2,3)(4,5) ) );;
-gap> Rc3 := GroupRing( GF(2), Group( (1,2,3) ) );;
-gap> homAR := AllHomsOfAlgebras( Ac6, Rc3 );;
-gap> mgiAR := List( homAR, h -> MappingGeneratorsImages(h) );;
-gap> Print( mgiAR, "\n" );
-[ [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ <zero> of ... ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*() ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], 
-      [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,3,2)(4,5) ], [ (Z(2)^0)*(1,3,2) ] ] ]
-gap> homRA := AllHomsOfAlgebras( Rc3, Ac6 );;
-gap> mgiRA := List( homRA, h -> MappingGeneratorsImages(h) );;
-gap> Print( mgiRA, "\n" );
-[ [ [ (Z(2)^0)*(1,2,3) ], [ <zero> of ... ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*() ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ],
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*()+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2) ] ], 
-  [ [ (Z(2)^0)*(1,2,3) ], [ (Z(2)^0)*(1,3,2) ] ] ]
-gap> C4 := PreCat1AlgebraByTailHeadEmbedding( homAR[6], homAR[6], homRA[8] );
-[AlgebraWithOne( GF(2), [ (Z(2)^0)*(1,2,3)(4,5) ] ) -> AlgebraWithOne( GF(2), 
-[ (Z(2)^0)*(1,2,3) ] )]
+gap> ## Chapter 2,  Section 2.1.2 
+gap> t4 := homAR[8]; 
+[ (Z(2)^0)*(1,6,5,4,3,2) ] -> [ (Z(2)^0)*(7,9,8) ]
+gap> e4 := homRA[8];
+[ (Z(2)^0)*(7,8,9) ] -> [ (Z(2)^0)*(1,5,3)(2,6,4) ]
+gap> C4 := PreCat1AlgebraByTailHeadEmbedding( t4, t4, e4 );
+[AlgebraWithOne( GF(2), [ (Z(2)^0)*(1,2,3,4,5,6) 
+ ] ) -> AlgebraWithOne( GF(2), [ (Z(2)^0)*(7,8,9) ] )]
 gap> IsCat1Algebra( C4 );
 true
 gap> Size( C4 );
@@ -65,23 +45,23 @@ gap> Display( C4 );
 
 Cat1-algebra [..=>..] :- 
 : source algebra has generators:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3)(4,5) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3,4,5,6) ]
 :  range algebra has generators:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,2,3) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(7,8,9) ]
 : tail homomorphism maps source generators to:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,3,2) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(7,8,9) ]
 : head homomorphism maps source generators to:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,3,2) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(7,8,9) ]
 : range embedding maps range generators to:
-  [ (Z(2)^0)*(), (Z(2)^0)*(1,3,2) ]
+  [ (Z(2)^0)*(), (Z(2)^0)*(1,5,3)(2,6,4) ]
 : kernel has generators:
-  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
+  [ (Z(2)^0)*()+(Z(2)^0)*(1,4)(2,5)(3,6), (Z(2)^0)*(1,2,3,4,5,6)+(Z(2)^0)*
+    (1,5,3)(2,6,4), (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,6,5,4,3,2) ]
 : boundary homomorphism maps generators of kernel to:
   [ <zero> of ..., <zero> of ..., <zero> of ... ]
 : kernel embedding maps generators of kernel to:
-  [ (Z(2)^0)*()+(Z(2)^0)*(4,5), (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,2,3)(4,5), 
-  (Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3,2)(4,5) ]
+  [ (Z(2)^0)*()+(Z(2)^0)*(1,4)(2,5)(3,6), (Z(2)^0)*(1,2,3,4,5,6)+(Z(2)^0)*
+    (1,5,3)(2,6,4), (Z(2)^0)*(1,3,5)(2,4,6)+(Z(2)^0)*(1,6,5,4,3,2) ]
 
 gap> ############################
 gap> ## Chapter 2,  Section 2.1.3

--- a/tst/convert.tst
+++ b/tst/convert.tst
@@ -28,27 +28,41 @@ gap> IsAlgebraHomomorphism( bdy );;
 gap> XM := PreXModAlgebraByBoundaryAndAction( bdy, act );;
 gap> IsXModAlgebra( XM );;
 
+gap> F := GF(5);;
+gap> one := One(F);;
+gap> two := Z(5);; 
+gap> z := Zero( F );; 
+gap> l := [ [one,z,z], [z,one,z], [z,z,one] ];; 
+gap> m := [ [z,one,two^3], [z,z,one], [z,z,z] ];;
+gap> n := [ [z,z,one], [z,z,z], [z,z,z] ];; 
+gap> A := Algebra( F, [l,m] );; 
+gap> SetName( A, "A(l,m)" ); 
+gap> B := Subalgebra( A, [m] );; 
+gap> SetName( B, "A(m)" ); 
+gap> IsIdeal( A, B );; 
+gap> act := AlgebraActionByMultiplication( A, B );; 
+gap> XAB := XModAlgebraByIdeal( A, B );; 
+gap> SetName( XAB, "XAB" ); 
+
 gap> ############################ 
 gap> ## Chapter 4,  Section 4.1.1
-gap> CXM := Cat1AlgebraOfXModAlgebra( XM );
-[GF(2^2)[k4] IX <e5> -> GF(2^2)[k4]]
-gap> Display( CXM );
+gap> CAB := Cat1AlgebraOfXModAlgebra( XAB );
+[Algebra( GF(5), [ v.1, v.2, v.3, v.4, v.5 ] ) -> A(l,m)]
+gap> Display( CAB );
 
-Cat1-algebra [..=>GF(2^2)[k4]] :- 
+Cat1-algebra [..=>A(l,m)] :- 
 :  range algebra has generators:
-  [ (Z(2)^0)*<identity> of ..., (Z(2)^0)*f1, (Z(2)^0)*f2 ]
+  
+[ 
+  [ [ Z(5)^0, 0*Z(5), 0*Z(5) ], [ 0*Z(5), Z(5)^0, 0*Z(5) ], 
+      [ 0*Z(5), 0*Z(5), Z(5)^0 ] ], 
+  [ [ 0*Z(5), Z(5)^0, Z(5)^3 ], [ 0*Z(5), 0*Z(5), Z(5)^0 ], 
+      [ 0*Z(5), 0*Z(5), 0*Z(5) ] ] ]
 : tail homomorphism maps source generators to:
 : range embedding maps range generators to:
-  [ [ (Z(2)^0)*<identity> of ..., <zero> of ... ], 
-  [ (Z(2)^0)*f1, <zero> of ... ], [ (Z(2)^0)*f2, <zero> of ... ] ]
+  [ v.1, v.2 ]
 : kernel has generators:
-  [ [ <zero> of ..., <zero> of ... ], 
-  [ <zero> of ..., (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^
-        0)*f1*f2 ], 
-  [ <zero> of ..., (Z(2^2))*<identity> of ...+(Z(2^2))*f1+(Z(2^2))*f2+(
-        Z(2^2))*f1*f2 ], 
-  [ <zero> of ..., (Z(2^2)^2)*<identity> of ...+(Z(2^2)^2)*f1+(Z(2^2)^2)*f2+(
-        Z(2^2)^2)*f1*f2 ] ]
+  Algebra( GF(5), [ v.4, v.5 ] )
 
 gap> X3 := XModAlgebraOfCat1Algebra( C3 ); 
 [ <algebra of dimension 3 over GF(2)> -> <algebra of dimension 3 over GF(2)> ]

--- a/tst/xmod.tst
+++ b/tst/xmod.tst
@@ -7,25 +7,26 @@ gap> saved_infolevel_xmodalg := InfoLevel( InfoXModAlg );;
 gap> SetInfoLevel( InfoXModAlg, 0 );
 
 ## Chapter 3, Section 3.1.2 
-gap> m := [ [ 0, 1, 2, 3 ], [ 0, 0, 4, 5 ], [0, 0, 0, 6 ], [ 0, 0, 0, 0 ] ];; 
-gap> A := Algebra( Rationals, [ m ] );
-<algebra over Rationals, with 1 generators>
-gap> m^2; m^3;
-[ [ 0, 0, 4, 17 ], [ 0, 0, 0, 24 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]
-[ [ 0, 0, 0, 24 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]
-gap> B := Subalgebra( A, [ m^2, m^3 ] );;  
-gap> X1 := XModAlgebraByIdeal( A, B ); 
-[ <algebra of dimension 2 over Rationals> -> <algebra of dimension 
-3 over Rationals> ]
-gap> act1 := XModAlgebraAction( X1 );; 
-gap> aut1 := ImageElm( act1, m );; 
-gap> ImageElm( aut1, m^2 );
-[ [ 0, 0, 0, 24 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]
+gap> F := GF(5);;
+gap> one := One(F);;
+gap> two := Z(5);; 
+gap> z := Zero( F );; 
+gap> l := [ [one,z,z], [z,one,z], [z,z,one] ];; 
+gap> m := [ [z,one,two^3], [z,z,one], [z,z,z] ];;
+gap> n := [ [z,z,one], [z,z,z], [z,z,z] ];; 
+gap> A := Algebra( F, [l,m] );; 
+gap> SetName( A, "A(l,m)" ); 
+gap> B := Subalgebra( A, [m] );; 
+gap> SetName( B, "A(m)" ); 
+gap> IsIdeal( A, B ); 
+true
+gap> act := AlgebraActionByMultiplication( A, B );; 
+gap> XAB := XModAlgebraByIdeal( A, B ); 
+[ A(m) -> A(l,m) ]
+gap> SetName( XAB, "XAB" ); 
+
 
 ## Chapter 3, Section 3.1.3 
-
-
-
 
 gap> Ak4 := GroupRing( GF(5), DihedralGroup(4) );
 <algebra-with-one over GF(5), with 2 generators>
@@ -146,9 +147,9 @@ gap> XIBk4 := XModAlgebra( Bk4, IBk4 );
 [ I(GF2[k4]) -> GF2[k4] ]
 gap> IAc4 = IBk4;
 false
-gap> homIAIB := AllHomsOfAlgebras( IAc4, IBk4 );; 
+gap> homIAIB := AllAlgebraHomomorphisms( IAc4, IBk4 );; 
 gap> theta := homIAIB[3];; 
-gap> homAB := AllHomsOfAlgebras( Ac4, Bk4 );;
+gap> homAB := AllAlgebraHomomorphisms( Ac4, Bk4 );;
 gap> phi := homAB[7];; 
 gap> mor := XModAlgebraMorphism( XIAc4, XIBk4, theta, phi );
 [[I(GF2[c4])->GF2[c4]] => [I(GF2[k4])->GF2[k4]]]


### PR DESCRIPTION
The new version of Cat1AlgebraOfXModAlgebra uses yesterday's new SemidirectProductOfAlgebras. 
Also, the All(Bijective/Idempotent)HomsOfAlgebras operations have been moved to algebra.{gd,gi} and renamed All(Bijective/Idempotent)AlgebraHomomorphisms, and a ManSection added in chapter 2. 