### PR TITLE
correct PR#70 - no test with stable-4.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,3 +56,4 @@ jobs:
         with:
           name: manual
           path: ./doc/manual.pdf
+          if-no-files-found: error


### PR DESCRIPTION
XModAlg requires XMod >= 2.87 so cannot run tests with stable-4.11.