### PR TITLE
no longer test against 4.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,6 @@ jobs:
           - stable-4.14
           - stable-4.13
           - stable-4.12
-          - stable-4.11
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The CI test with GAP 4.11 always fails: "XModAlg not available."  So remove 4.11 from CI.yml.